### PR TITLE
increase ebs volume size for snapshot node from 250 gib to 500 gib

### DIFF
--- a/indexer/snapshot_full_node_ap_northeast_1.tf
+++ b/indexer/snapshot_full_node_ap_northeast_1.tf
@@ -41,6 +41,8 @@ module "full_node_snapshot_ap_northeast_1" {
 
   datadog_env = "snapshot-${var.environment}"
 
+  root_block_device_size = 500
+
   entry_point = [
     "sh",
     "-c",


### PR DESCRIPTION
fixes memory issue once snapshot is ~150 gb