### PR TITLE
Control snapshot node's home directory separately

### DIFF
--- a/indexer/snapshot_full_node_ap_northeast_1.tf
+++ b/indexer/snapshot_full_node_ap_northeast_1.tf
@@ -18,7 +18,7 @@ module "full_node_snapshot_ap_northeast_1" {
     IsIndexerFullNode = true
   }
 
-  container_chain_home               = var.full_node_container_chain_home
+  container_chain_home               = var.snapshot_full_node_container_chain_home
   container_p2p_persistent_peers     = join(",", var.full_node_container_p2p_persistent_peers)
   container_non_validating_full_node = true
 

--- a/indexer/variables.tf
+++ b/indexer/variables.tf
@@ -157,6 +157,11 @@ variable "full_node_container_chain_home" {
   description = "Full-node's home directory for the chain. Used to boot up the chain, and configure the `cmd` in ECS"
 }
 
+variable "snapshot_full_node_container_chain_home" {
+  type        = string
+  description = "Snapshot full-node's home directory for the chain. Used to boot up the chain, and configure the `cmd` in ECS"
+}
+
 variable "full_node_key" {
   type        = string
   description = "Full node's P2P key, used by other nodes for P2P"


### PR DESCRIPTION
Snapshot node uses `local_node` as its home directory. Previously this didn't matter because it had its own entrypoint, but now that we are using cosmovisor, `DAEMON_HOME` (which is set from `container_chain_home`) needs to be set correctly so cosmovisor can use it.