### PR TITLE
[IND-405] set memory/cpu explicitly for Indexer service containers

### DIFF
--- a/indexer/ecs.tf
+++ b/indexer/ecs.tf
@@ -106,7 +106,7 @@ resource "aws_ecs_task_definition" "main" {
             awslogs-stream-prefix = "ecs"
           }
         }
-        cpu = each.value.task_definition_cpu - module.datadog_agent.datadog_cpu
+        cpu               = each.value.task_definition_cpu - module.datadog_agent.datadog_cpu
         memoryReservation = each.value.task_definition_memory - module.datadog_agent.datadog_memory
         portMappings = [
           for port in each.value.ports : {

--- a/indexer/ecs.tf
+++ b/indexer/ecs.tf
@@ -106,6 +106,8 @@ resource "aws_ecs_task_definition" "main" {
             awslogs-stream-prefix = "ecs"
           }
         }
+        cpu = each.value.task_definition_cpu - module.datadog_agent.datadog_cpu
+        memoryReservation = each.value.task_definition_memory - module.datadog_agent.datadog_memory
         portMappings = [
           for port in each.value.ports : {
             containerPort : port,

--- a/modules/datadog_agent/output.tf
+++ b/modules/datadog_agent/output.tf
@@ -12,3 +12,13 @@ output "ecs_ec2_container_volumes" {
   value       = local.ecs_ec2_container_volumes
   description = "container volumes for Datadog sidecar for ECS EC2"
 }
+
+output "datadog_cpu" {
+  value       = var.container_cpu_units
+  description = "The number of cpu units to reserve for the datadog agent container."
+}
+
+output "datadog_memory" {
+  value       = var.container_memory_reservation
+  description = "The amount of memory (in MiB) to reserve for the datadog agent container."
+}


### PR DESCRIPTION
I was investigating Indexer latency issues in dev5. There was a big [increase](https://app.datadoghq.com/dashboard/tn3-bgn-9jr/v4-indexer?refresh_mode=paused&tpl_var_cluster_name%5B0%5D=dev5-indexer-apne1-cluster&tpl_var_cluster%5B0%5D=dev5-indexer-apne1-cluster&tpl_var_container_name%5B0%5D=%2A&tpl_var_ecs_cluster_name%5B0%5D=%2A&tpl_var_ecs_task_family%5B0%5D=%2A&tpl_var_Environment%5B0%5D=dev5&tpl_var_msk_cluster_name%5B0%5D=dev5-indexer-apne1-msk-cluster&tpl_var_project%5B0%5D=v4&tpl_var_region%5B0%5D=%2A&tpl_var_Service%5B0%5D=indexer&tpl_var_task_name%5B0%5D=%2A&from_ts=1696392552286&to_ts=1696444118000&live=false) in processing latency starting at 6 am today, causing us to lag behind the network. I verified this had nothing to do with valdiator <-> full node latency. Nothing changed except for a big decrease in CPU usage percent at the same time. By explicitly setting cpu in the container definition, I see CPU usage go back to prior level and processing latency decrease. See this [dashboard](https://app.datadoghq.com/dashboard/tn3-bgn-9jr/v4-indexer?refresh_mode=paused&tpl_var_cluster_name%5B0%5D=dev5-indexer-apne1-cluster&tpl_var_cluster%5B0%5D=dev5-indexer-apne1-cluster&tpl_var_container_name%5B0%5D=%2A&tpl_var_ecs_cluster_name%5B0%5D=%2A&tpl_var_ecs_task_family%5B0%5D=%2A&tpl_var_Environment%5B0%5D=dev5&tpl_var_msk_cluster_name%5B0%5D=dev5-indexer-apne1-msk-cluster&tpl_var_project%5B0%5D=v4&tpl_var_region%5B0%5D=%2A&tpl_var_Service%5B0%5D=indexer&tpl_var_task_name%5B0%5D=%2A&from_ts=1696439958633&to_ts=1696445812000&live=false).

This PR explicitly sets the memoryReservation/cpu fields in terraform. In staging environment, we see significant correlation between memory usage and processing latency. For FARGATE, memoryReservation represents a soft lower bound.