### PR TITLE
Add secrets access to task roles.

### DIFF
--- a/indexer/ecs.tf
+++ b/indexer/ecs.tf
@@ -81,8 +81,8 @@ resource "aws_ecs_task_definition" "main" {
 
   family                   = "${var.environment}-${var.indexers[var.region].name}-${each.key}-task"
   network_mode             = "awsvpc"
-  execution_role_arn       = module.iam_ecs_task_roles.ecs_task_execution_role_arn
-  task_role_arn            = module.iam_ecs_task_roles.ecs_task_role_arn
+  execution_role_arn       = module.iam_service_ecs_task_roles[each.key].ecs_task_execution_role_arn
+  task_role_arn            = module.iam_service_ecs_task_roles[each.key].ecs_task_role_arn
   requires_compatibilities = ["FARGATE"]
   cpu                      = each.value.task_definition_cpu
   memory                   = each.value.task_definition_memory
@@ -142,6 +142,10 @@ resource "aws_ecs_task_definition" "main" {
             {
               name  = "SEND_BUGSNAG_ERRORS",
               value = tostring(var.send_bugsnag_errors)
+            },
+            {
+              name  = "SECRET_ID",
+              value = local.service_secret_ids[each.key],
             },
             each.value.ecs_environment_variables,
             each.value.requires_postgres_connection ? local.postgres_environment_variables : [],

--- a/indexer/iam.tf
+++ b/indexer/iam.tf
@@ -16,7 +16,7 @@ module "iam_service_ecs_task_roles" {
 }
 
 // Legacy, delete after all environments have been migrated to using per task ECS roles.
-// Needed so that existing running ECS tasks depend on this ECS role.
+// Needed as existing running ECS tasks depend on this ECS role.
 module "iam_ecs_task_roles" {
   source                        = "../modules/iam/ecs_task_roles"
   name                          = var.indexers[var.region].name

--- a/indexer/iam.tf
+++ b/indexer/iam.tf
@@ -15,6 +15,8 @@ module "iam_service_ecs_task_roles" {
   )
 }
 
+// Legacy, delete after all environments have been migrated to using per task ECS roles.
+// Needed so that existing running ECS tasks depend on this ECS role.
 module "iam_ecs_task_roles" {
   source                        = "../modules/iam/ecs_task_roles"
   name                          = var.indexers[var.region].name

--- a/indexer/locals.tf
+++ b/indexer/locals.tf
@@ -6,6 +6,7 @@ locals {
 }
 
 locals {
+  // Needed so that there are no circular dependencies for all resources are created per service names.
   service_names = {
     "ender" : "ender",
     "comlink" : "comlink",

--- a/indexer/locals.tf
+++ b/indexer/locals.tf
@@ -6,8 +6,22 @@ locals {
 }
 
 locals {
+  service_names = {
+    "ender" : "ender",
+    "comlink" : "comlink",
+    "socks" : "socks",
+    "roundtable" : "roundtable",
+    "vulcan" : "vulcan"
+  }
+
+  service_secret_ids = {
+    for name in local.service_names : name => "${var.environment}-${name}-secrets"
+  }
+}
+
+locals {
   services = {
-    "ender" : {
+    "${local.service_names["ender"]}" : {
       ecs_desired_count : 1,
       task_definition_memory : 8192,
       task_definition_cpu : 4096,
@@ -20,7 +34,7 @@ locals {
       should_deploy_in_rds_subnet : true,
       ecs_environment_variables : [],
     },
-    "comlink" : {
+    "${local.service_names["comlink"]}" : {
       ecs_desired_count : 5,
       task_definition_memory : 4096,
       task_definition_cpu : 2048,
@@ -54,7 +68,7 @@ locals {
         value : var.indexer_compliance_blocklist,
       }],
     },
-    "socks" : {
+    "${local.service_names["socks"]}" : {
       ecs_desired_count : 5,
       task_definition_memory : 20480,
       task_definition_cpu : 4096,
@@ -80,7 +94,7 @@ locals {
         },
       ],
     },
-    "roundtable" : {
+    "${local.service_names["roundtable"]}" : {
       ecs_desired_count : 5,
       task_definition_memory : 4096,
       task_definition_cpu : 2048,
@@ -106,7 +120,7 @@ locals {
         },
         {
           name : "ECS_TASK_ROLE_ARN",
-          value : module.iam_ecs_task_roles.ecs_task_role_arn,
+          value : module.iam_service_ecs_task_roles["roundtable"].ecs_task_role_arn,
         },
         {
           name : "S3_BUCKET_ARN",
@@ -126,7 +140,7 @@ locals {
         },
       ],
     },
-    "vulcan" : {
+    "${local.service_names["vulcan"]}" : {
       ecs_desired_count : 5,
       task_definition_memory : 8192,
       task_definition_cpu : 4096,

--- a/indexer/locals.tf
+++ b/indexer/locals.tf
@@ -6,13 +6,16 @@ locals {
 }
 
 locals {
+  service_names_list = [
+    "ender",
+    "comlink",
+    "socks",
+    "roundtable",
+    "vulcan",
+  ]
   // Needed so that there are no circular dependencies for all resources are created per service names.
   service_names = {
-    "ender" : "ender",
-    "comlink" : "comlink",
-    "socks" : "socks",
-    "roundtable" : "roundtable",
-    "vulcan" : "vulcan"
+    for name in local.service_names_list : name => name
   }
 
   service_secret_ids = {

--- a/indexer/locals.tf
+++ b/indexer/locals.tf
@@ -163,6 +163,11 @@ locals {
             name : "BLOCKED_ADDRESSES",
             value : var.indexer_compliance_blocklist,
           },
+          {
+            name : "PG_POOL_MAX",
+            value : "2"
+          },
+          var.roundtable_ecs_environment_variables,
         ],
       ),
     },


### PR DESCRIPTION
Note on the circular dependency that required the use of a new local variable for service names:

The secret roles I added need to loop over each service, and are used to create the ECS task role. The ECS task role is passed into the environment variables for `roundtable` in the service. If the secret roles depended on the `services` local, this causes a circular dependency.

This is good for the future as well, if we need to create any other resource per service, we should only loop over the names of the services if we don't need any of the details inside `local.services`, as there are more and more dependencies / data in `local.services`.