### PR TITLE
Parametrize DataDog API site in Metric Ingestor module

### DIFF
--- a/metric_ingestor/metric_ingestor.tf
+++ b/metric_ingestor/metric_ingestor.tf
@@ -7,6 +7,7 @@ module "metric_ingestor" {
   name        = "metric-ingestor"
 
   datadog_api_key = var.datadog_api_key
+  datadog_site    = var.datadog_site
 
   validators = var.validators
 

--- a/metric_ingestor/variables.tf
+++ b/metric_ingestor/variables.tf
@@ -10,6 +10,12 @@ variable "datadog_app_key" {
   sensitive   = true
 }
 
+variable "datadog_site" {
+  type        = string
+  description = "Datadog API site to send data to"
+  default     = null
+}
+
 variable "environment" {
   type        = string
   description = "Name of the environment {dev | dev2 | dev3 | dev4 | dev5 | staging | testnet | public-testnet | testnet1 | testnet2}."

--- a/modules/datadog_agent/variables.tf
+++ b/modules/datadog_agent/variables.tf
@@ -65,5 +65,6 @@ variable "docker_image_tag" {
 variable "dd_site" {
   type        = string
   default     = "datadoghq.com"
+  nullable    = false
   description = "The site that the datadog agent will send data to"
 }

--- a/modules/metric_ingestor/datadog.tf
+++ b/modules/metric_ingestor/datadog.tf
@@ -3,6 +3,7 @@ module "datadog_agent" {
 
   env             = var.environment
   datadog_api_key = var.datadog_api_key
+  dd_site         = var.datadog_site
   service_name    = "metric-ingestor"
 
   # https://docs.datadoghq.com/containers/docker/prometheus/?tabs=standard#configuration

--- a/modules/metric_ingestor/variables.tf
+++ b/modules/metric_ingestor/variables.tf
@@ -37,6 +37,12 @@ variable "datadog_api_key" {
   sensitive   = true
 }
 
+variable "datadog_site" {
+  type        = string
+  description = "Datadog API site to send data to"
+  default     = null
+}
+
 variable "metrics_namespace" {
   type        = string
   description = "metrics namespace"


### PR DESCRIPTION
The goal of this PR is to allow passing DataDog module's DD_SITE parameter for Metric Ingestor.

`nullable = false` is used to ensure compatibility with existing Metric Ingestor configurations: when `null` parameter is passed into `datadog_agent` module, the `site` parameter will still keep its default value.