### PR TITLE
Update indexer monitors.

### DIFF
--- a/modules/indexer_monitors/monitors.tf
+++ b/modules/indexer_monitors/monitors.tf
@@ -1,60 +1,3 @@
-resource "datadog_monitor_json" "best_bid" {
-  monitor = <<EOF
-{
-	"name": "[${var.environment}] Indexer Orderbook best bid has not changed for 10 minutes for pair {{clob_pair_id.name}}",
-	"type": "query alert",
-	"query": "max(last_10m):abs(derivative(avg:roundtable.crossed_orderbook.best_bid_human{env:${var.environment},!clob_pair_id:33} by {clob_pair_id})) <= 0",
-  "message": "${local.monitor_suffix_literal}",
-	"tags": [
-		"team:${var.team}",
-		"env:${var.env_tag}"
-	],
-	"options": {
-		"thresholds": {
-			"critical": 0
-		},
-		"notify_audit": false,
-		"require_full_window": false,
-		"notify_no_data": false,
-		"renotify_interval": 0,
-		"include_tags": true,
-		"new_group_delay": 60
-	},
-	"priority": null,
-	"restricted_roles": null
-}
-EOF
-}
-
-resource "datadog_monitor_json" "best_ask" {
-  monitor = <<EOF
-{
-	"id": 127134448,
-	"name": "[${var.environment}] Indexer Orderbook best ask has not changed for 10 minutes for pair {{clob_pair_id.name}}",
-	"type": "query alert",
-	"query": "max(last_10m):abs(derivative(avg:roundtable.crossed_orderbook.best_ask_human{env:${var.environment},!clob_pair_id:33} by {clob_pair_id})) <= 0",
-  "message": "${local.monitor_suffix_literal}",
-	"tags": [
-		"team:${var.team}",
-		"env:${var.env_tag}"
-	],
-	"options": {
-		"thresholds": {
-			"critical": 0
-		},
-		"notify_audit": false,
-		"require_full_window": false,
-		"notify_no_data": false,
-		"renotify_interval": 0,
-		"include_tags": true,
-		"new_group_delay": 60
-	},
-	"priority": null,
-	"restricted_roles": null
-}
-EOF
-}
-
 resource "datadog_monitor_json" "socks_kafka_offset" {
   monitor = <<EOF
 {
@@ -95,7 +38,7 @@ resource "datadog_monitor_json" "orderbook_crossed" {
 	"id": 120397508,
 	"name": "[${var.environment}] Indexer Orderbook crossed for {{clob_pair_id.name}}",
 	"type": "query alert",
-	"query": "max(last_10m):avg:roundtable.crossed_orderbook.best_ask_human{env:${var.environment},!clob_pair_id:33} by {clob_pair_id} - avg:roundtable.crossed_orderbook.best_bid_human{env:${var.environment},!clob_pair_id:33} by {clob_pair_id} < 0",
+	"query": "max(last_10m):default_zero(avg:roundtable.crossed_orderbook.best_ask_human{env:testnet,!clob_pair_id:33} by {clob_pair_id} - avg:roundtable.crossed_orderbook.best_bid_human{env:testnet,!clob_pair_id:33} by {clob_pair_id}) < 0",
 	"message": "Orderbook has been crossed for more than 10 minutes for {{clob_pair_id.name}} . This may be an instance of a stale orderbook level that was not removed.\n\nImpact:\nThe stale orderbook level will affect the FE and API, leading users to have inaccurate assumptions of what price orders will fill at.\n\nResolution:\nClear the stale orderbook levels from redis.\n\n${local.monitor_suffix_literal}",
 	"tags": [
 		"team:${var.team}",

--- a/modules/indexer_monitors/monitors.tf
+++ b/modules/indexer_monitors/monitors.tf
@@ -38,7 +38,7 @@ resource "datadog_monitor_json" "orderbook_crossed" {
 	"id": 120397508,
 	"name": "[${var.environment}] Indexer Orderbook crossed for {{clob_pair_id.name}}",
 	"type": "query alert",
-	"query": "max(last_10m):default_zero(avg:roundtable.crossed_orderbook.best_ask_human{env:testnet,!clob_pair_id:33} by {clob_pair_id} - avg:roundtable.crossed_orderbook.best_bid_human{env:testnet,!clob_pair_id:33} by {clob_pair_id}) < 0",
+	"query": "max(last_10m):default_zero(avg:roundtable.crossed_orderbook.best_ask_human{env:${var.environment},!clob_pair_id:33} by {clob_pair_id} - avg:roundtable.crossed_orderbook.best_bid_human{env:${var.environment},!clob_pair_id:33} by {clob_pair_id}) < 0",
 	"message": "Orderbook has been crossed for more than 10 minutes for {{clob_pair_id.name}} . This may be an instance of a stale orderbook level that was not removed.\n\nImpact:\nThe stale orderbook level will affect the FE and API, leading users to have inaccurate assumptions of what price orders will fill at.\n\nResolution:\nClear the stale orderbook levels from redis.\n\n${local.monitor_suffix_literal}",
 	"tags": [
 		"team:${var.team}",


### PR DESCRIPTION
Remove best bid / best ask monitors as they don't account for order books with low volume.
Update metric for order book crossed monitor to default to zero when there is no data so that order books with low volume do not cause false positives.

Back-tested against order books with low volume and verified the metric was 0, and also back-tested against cases where the order book was crossed for an extended period of time and the metric was negative.