### PR TITLE
Update Ender Block Processing dashboard

### DIFF
--- a/modules/indexer_dashboards/ender_dashboard.tf
+++ b/modules/indexer_dashboards/ender_dashboard.tf
@@ -419,14 +419,9 @@ resource "datadog_dashboard_json" "ender" {
                   ],
                   "queries": [
                     {
-                      "query": "avg:ender.processing_block_height{$Environment,$Service}",
+                      "query": "max:ender.processing_block_height{$Environment,$Service}",
                       "data_source": "metrics",
                       "name": "query1"
-                    },
-                    {
-                      "query": "max:dydxprotocol.tendermint_consensus_height{$Environment}",
-                      "data_source": "metrics",
-                      "name": "query4"
                     },
                     {
                       "query": "max:dydxprotocol.cometbft_consensus_height{$Environment}",


### PR DESCRIPTION
- Remove deprecated `max:dydxprotocol.tendermint_consensus_height`
- Changed ender processing block height from avg to max, because during auxo deployment, there are two instances of ender, so avg is inaccurate and it looks like ender is lagging while auxo is redeploying ender