### PR TITLE
Toggle log_forwarder per indexer service

### DIFF
--- a/indexer/datadog.tf
+++ b/indexer/datadog.tf
@@ -16,12 +16,13 @@ module "datadog_log_forwarder_indexer_services" {
   source   = "../modules/datadog_agent/log_forwarder"
   for_each = local.services
 
-  environment     = var.environment
-  name            = "${var.environment}-${var.indexers[var.region].name}-${each.key}"
-  datadog_api_key = var.datadog_api_key
-  log_group_name  = aws_cloudwatch_log_group.services[each.key].name
-  filter_pattern  = local.log_level_filter_pattern[var.datadog_log_level]
-  dd_site         = var.dd_site
+  environment          = var.environment
+  name                 = "${var.environment}-${var.indexers[var.region].name}-${each.key}"
+  datadog_api_key      = var.datadog_api_key
+  log_group_name       = aws_cloudwatch_log_group.services[each.key].name
+  filter_pattern       = local.log_level_filter_pattern[var.datadog_log_level]
+  dd_site              = var.dd_site
+  disable_subscription = contains(var.services_disable_dd_log, each.key)
 }
 
 module "datadog_log_fowarder_indexer_lambda_services" {

--- a/indexer/variables.tf
+++ b/indexer/variables.tf
@@ -439,3 +439,9 @@ variable "public_access" {
   description = "Enables public access of the indexer endpoints."
   default     = true
 }
+
+variable "services_disable_dd_log" {
+  type        = list(string)
+  description = "List of services will disable the log forwarder subscription to datadog. "
+  default     = []
+}

--- a/modules/datadog_agent/log_forwarder/main.tf
+++ b/modules/datadog_agent/log_forwarder/main.tf
@@ -25,6 +25,7 @@ data "aws_lambda_function" "datadog_forwarder_lambda" {
 # CloudWatch Logs subscription filter, which filters and delivers the log content to the
 # Datadog lambda forwarder.
 resource "aws_cloudwatch_log_subscription_filter" "datadog_log_subscription_filter" {
+  count           = var.disable_subscription ? 0 : 1
   name            = "${var.environment}-${var.name}-datadog-log-subscription-filter"
   log_group_name  = var.log_group_name
   destination_arn = data.aws_lambda_function.datadog_forwarder_lambda.arn

--- a/modules/datadog_agent/log_forwarder/variables.tf
+++ b/modules/datadog_agent/log_forwarder/variables.tf
@@ -39,3 +39,8 @@ variable "dd_site" {
   description = "The site that the datadog agent will send data to"
 }
 
+variable "disable_subscription" {
+  type        = bool
+  description = "Disable datadog log forwarder or not. Default: false"
+  default     = false
+}


### PR DESCRIPTION
On production and testnet, Imperator need to disable log forwarder from `vulcan` and `socks` to Datadog to avoid flooding log from these services.

By default, `disable_subscription` is false so all services logs are forwarded to DD.
To disable, let say `vulcan` and `socks` logs, set the value below
`
services_disable_dd_log = ["vulcan", "socks"]
`