### PR TITLE
Disable RDS auto minor version upgrades.

### DIFF
--- a/indexer/rds.tf
+++ b/indexer/rds.tf
@@ -201,6 +201,7 @@ resource "aws_db_instance" "main" {
   delete_automated_backups              = false
   performance_insights_enabled          = true
   performance_insights_retention_period = 31
+  auto_minor_version_upgrade = false
 
   tags = {
     Name        = local.aws_db_instance_main_name
@@ -222,6 +223,7 @@ resource "aws_db_instance" "read_replica" {
   skip_final_snapshot                   = true
   performance_insights_enabled          = true
   performance_insights_retention_period = 31
+  auto_minor_version_upgrade = false
 
   replicate_source_db = aws_db_instance.main.identifier
 

--- a/indexer/rds.tf
+++ b/indexer/rds.tf
@@ -201,7 +201,7 @@ resource "aws_db_instance" "main" {
   delete_automated_backups              = false
   performance_insights_enabled          = true
   performance_insights_retention_period = 31
-  auto_minor_version_upgrade = false
+  auto_minor_version_upgrade            = false
 
   tags = {
     Name        = local.aws_db_instance_main_name
@@ -223,7 +223,7 @@ resource "aws_db_instance" "read_replica" {
   skip_final_snapshot                   = true
   performance_insights_enabled          = true
   performance_insights_retention_period = 31
-  auto_minor_version_upgrade = false
+  auto_minor_version_upgrade            = false
 
   replicate_source_db = aws_db_instance.main.identifier
 


### PR DESCRIPTION
Disable auto minor version upgrades, instead these upgrades should be manually applied so that a status page / maintenance alert can be sent out ahead of time.