### PR TITLE
Increase replica lag alert params.

### DIFF
--- a/modules/indexer_monitors/precautionary_monitors.tf
+++ b/modules/indexer_monitors/precautionary_monitors.tf
@@ -66,7 +66,7 @@ resource "datadog_monitor_json" "rds_read_replica_lag" {
 	"id": 139995842,
 	"name": "[${var.environment}] RDS read replica lag is high",
 	"type": "query alert",
-	"query": "avg(last_5m):avg:aws.rds.replica_lag{name:*-indexer-apne1-db-read-replica, environment:${var.environment}} > 1",
+	"query": "avg(last_10m):avg:aws.rds.replica_lag{name:*-indexer-apne1-db-read-replica, environment:${var.environment}} > 2",
 	"message": "This is not an actionable alert. When this alert fires, that means that the RDS read replica lag is high.\n\n${local.monitor_suffix_literal}",
 	"tags": [
 		"team:${var.team}",


### PR DESCRIPTION
Increase params to the alert from:
- alerting when average replica lag in the last 5 minutes was greater than 1 second 
- to alerting when average replica lag in the last 10 minutes was greater than 2 seconds

The alert was firing too many false negatives where it immediately resolved.