### PR TITLE
Make datadog agent essential for metrics ingestor

### DIFF
--- a/modules/datadog_agent/main.tf
+++ b/modules/datadog_agent/main.tf
@@ -12,8 +12,8 @@ locals {
     name              = var.name
     image             = "${var.docker_image_name}:${var.docker_image_tag}",
     cpu               = var.container_cpu_units,
-    memoryReservation = var.essential,
-    essential         = false,
+    memoryReservation = var.container_memory_reservation,
+    essential         = var.essential,
 
     dockerLabels = var.docker_labels
 

--- a/modules/datadog_agent/main.tf
+++ b/modules/datadog_agent/main.tf
@@ -12,7 +12,7 @@ locals {
     name              = var.name
     image             = "${var.docker_image_name}:${var.docker_image_tag}",
     cpu               = var.container_cpu_units,
-    memoryReservation = var.container_memory_reservation,
+    memoryReservation = var.essential,
     essential         = false,
 
     dockerLabels = var.docker_labels

--- a/modules/datadog_agent/variables.tf
+++ b/modules/datadog_agent/variables.tf
@@ -68,3 +68,9 @@ variable "dd_site" {
   nullable    = false
   description = "The site that the datadog agent will send data to"
 }
+
+variable "essential" {
+  type        = bool
+  description = "Whether the datadog agent should be an essential container"
+  default     = false
+}

--- a/modules/metric_ingestor/datadog.tf
+++ b/modules/metric_ingestor/datadog.tf
@@ -5,6 +5,7 @@ module "datadog_agent" {
   datadog_api_key = var.datadog_api_key
   dd_site         = var.datadog_site
   service_name    = "metric-ingestor"
+  essential       = true
 
   # https://docs.datadoghq.com/containers/docker/prometheus/?tabs=standard#configuration
   docker_labels = {


### PR DESCRIPTION
Metrics ingestor only runs a DD agent container and no other containers. One container must be essential in order for it to spin up