### PR TITLE
Disable test flag.

### DIFF
--- a/indexer/locals.tf
+++ b/indexer/locals.tf
@@ -46,10 +46,6 @@ locals {
             name  = "PG_POOL_MIN",
             value = "10",
           },
-          {
-            name : "SEND_SUBACCOUNT_WEBSOCKET_MESSAGE_FOR_STATEFUL_ORDERS",
-            value : "true"
-          },
           var.ender_ecs_environment_variables,
         ],
       ),
@@ -218,10 +214,6 @@ locals {
           {
             name  = "PG_POOL_MIN",
             value = "1",
-          },
-          {
-            name  = "SEND_SUBACCOUNT_WEBSOCKET_MESSAGE_FOR_STATEFUL_ORDERS",
-            value = "false",
           },
           var.vulcan_ecs_environment_variables,
         ],


### PR DESCRIPTION
`SEND_SUBACCOUNT_WEBSOCKET_MESSAGE_FOR_STATEFUL_ORDERS` being `false` for `vulcan` and `true` for `ender` leads to stateful orders not showing up on the orderbook. 