### PR TITLE
[TRA-241] Add `exclude_metrics` to validator and metrics ingestor

### DIFF
--- a/modules/metric_ingestor/datadog.tf
+++ b/modules/metric_ingestor/datadog.tf
@@ -15,6 +15,7 @@ module "datadog_agent" {
           "openmetrics_endpoint" : validator.openmetrics_endpoint,
           "namespace" : var.metrics_namespace,
           "metrics" : var.metrics,
+          "exclude_metrics" : var.exclude_metrics,
           "tags" : ["validator_name:${validator.name}", "is_full_node:false"],
           "max_returned_metrics" : var.max_returned_metrics
         }

--- a/modules/metric_ingestor/variables.tf
+++ b/modules/metric_ingestor/variables.tf
@@ -71,6 +71,17 @@ variable "metrics" {
   ]
 }
 
+variable "exclude_metrics" {
+  type        = list(string)
+  description = <<-EOT
+    A list of metrics to exclude, with each entry being either
+	the exact metric name or a regular expression.
+	See https://docs.datadoghq.com/developers/custom_checks/prometheus/#going-further
+	or https://github.com/DataDog/integrations-core/blob/master/openmetrics/datadog_checks/openmetrics/data/conf.yaml.example#L112
+  EOT
+  default     = []
+}
+
 variable "max_returned_metrics" {
   type        = number
   description = "the number of metrics we allow `com.datadoghq.ad.instances` to return."

--- a/modules/validator/datadog.tf
+++ b/modules/validator/datadog.tf
@@ -14,6 +14,7 @@ module "datadog_agent" {
           "openmetrics_endpoint" : "http://%%host%%:${var.prometheus_port}/metrics?format=prometheus",
           "namespace" : var.metrics_namespace,
           "metrics" : var.metrics,
+          "exclude_metrics" : var.exclude_metrics,
           "tags" : ["validator_name:dydx", "is_full_node:${var.container_non_validating_full_node}"],
           "max_returned_metrics" : var.max_returned_metrics
         }

--- a/modules/validator/variables.tf
+++ b/modules/validator/variables.tf
@@ -181,6 +181,19 @@ variable "metrics" {
   ]
 }
 
+variable "exclude_metrics" {
+  type        = list(string)
+  description = <<-EOT
+    A list of metrics to exclude, with each entry being either
+	the exact metric name or a regular expression.
+	See https://docs.datadoghq.com/developers/custom_checks/prometheus/#going-further
+	or https://github.com/DataDog/integrations-core/blob/master/openmetrics/datadog_checks/openmetrics/data/conf.yaml.example#L112
+  EOT
+  default = [
+    ".*cometbft_p2p.*" // Exclude cometbft_p2p metrics. These are not useful for monitoring historically.
+  ]
+}
+
 variable "max_returned_metrics" {
   type        = number
   description = "the number of metrics we allow `com.datadoghq.ad.instances` to return."

--- a/modules/validator/variables.tf
+++ b/modules/validator/variables.tf
@@ -189,9 +189,7 @@ variable "exclude_metrics" {
 	See https://docs.datadoghq.com/developers/custom_checks/prometheus/#going-further
 	or https://github.com/DataDog/integrations-core/blob/master/openmetrics/datadog_checks/openmetrics/data/conf.yaml.example#L112
   EOT
-  default = [
-    ".*cometbft_p2p.*" // Exclude cometbft_p2p metrics. These are not useful for monitoring historically.
-  ]
+  default     = []
 }
 
 variable "max_returned_metrics" {


### PR DESCRIPTION
This allows deployer to specify which metrics to exclude when forwarding to DD.

Some examples of metrics to exclude:
* `.*cometbft_p2p.*`