### PR TITLE
feat(metric_ingestor): allow histograms to be ingested as DataDog distributions

### DIFF
--- a/modules/metric_ingestor/datadog.tf
+++ b/modules/metric_ingestor/datadog.tf
@@ -17,7 +17,8 @@ module "datadog_agent" {
           "metrics" : var.metrics,
           "exclude_metrics" : var.exclude_metrics,
           "tags" : ["validator_name:${validator.name}", "is_full_node:false"],
-          "max_returned_metrics" : var.max_returned_metrics
+          "max_returned_metrics" : var.max_returned_metrics,
+          "histogram_buckets_as_distributions" : true
         }
       ]
     ),


### PR DESCRIPTION
This will allow metrics such as `app_abci_method_latency` to be properly explored in DataDog.