### PR TITLE
Replace ec2connect with ssm

### DIFF
--- a/amplitude_api_gateway/providers.tf
+++ b/amplitude_api_gateway/providers.tf
@@ -1,6 +1,6 @@
 terraform {
   cloud {
-    organization = "dydxprotocol"
+    organization = "dydxopsdao"
 
     workspaces {
       name = ["amplitude-api-gateway"]
@@ -10,11 +10,11 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 3.0"
+      version = "~> 5.32"
     }
   }
 
-  required_version = "~> 1.3.2"
+  required_version = "~> 1.5"
 }
 
 provider "aws" {

--- a/indexer/variables.tf
+++ b/indexer/variables.tf
@@ -74,7 +74,7 @@ variable "bugsnag_release_stage" {
       ["development", "staging", "testnet", "mainnet"],
       var.bugsnag_release_stage
     )
-    error_message = "Err: invalid bugsnag release stage. Must be one of {development | staging | testnet}."
+    error_message = "Err: invalid bugsnag release stage. Must be one of {development | staging | testnet | mainnet}."
   }
 }
 

--- a/indexer/variables.tf
+++ b/indexer/variables.tf
@@ -71,7 +71,7 @@ variable "bugsnag_release_stage" {
 
   validation {
     condition = contains(
-      ["development", "staging", "testnet"],
+      ["development", "staging", "testnet", "mainnet"],
       var.bugsnag_release_stage
     )
     error_message = "Err: invalid bugsnag release stage. Must be one of {development | staging | testnet}."

--- a/modules/metric_ingestor/ec2.tf
+++ b/modules/metric_ingestor/ec2.tf
@@ -10,10 +10,6 @@ locals {
   user_data = <<EOH
 #!/bin/bash
 
-# Install ECS instance connect
-yum update -y
-yum install ec2-instance-connect -y
-
 # Register this EC2 instance to the ECS cluster
 echo ECS_CLUSTER=${aws_ecs_cluster.main.name} >> /etc/ecs/ecs.config
 EOH

--- a/modules/metric_ingestor/iam.tf
+++ b/modules/metric_ingestor/iam.tf
@@ -63,3 +63,12 @@ resource "aws_iam_role_policy_attachment" "ecs_list_tags" {
   role       = aws_iam_role.ecs_instance_iam_role.name
   policy_arn = aws_iam_policy.ecs_list_tags_policy.arn
 }
+
+# -----------------------------------------------------------------------------
+# SSM policy for the ECS instance role to support secure management
+# -----------------------------------------------------------------------------
+
+resource "aws_iam_role_policy_attachment" "ssm_policy_attachment" {
+  role       = aws_iam_role.ecs_instance_iam_role.name
+  policy_arn = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
+}

--- a/modules/metric_ingestor/security_group.tf
+++ b/modules/metric_ingestor/security_group.tf
@@ -3,6 +3,14 @@ resource "aws_security_group" "main" {
   name   = "${var.environment}-${var.name}-sg"
   vpc_id = aws_vpc.main.id
 
+  ingress {
+    protocol         = "-1"
+    from_port        = 0
+    to_port          = 0
+    cidr_blocks      = []
+    ipv6_cidr_blocks = []
+  }
+
   # For outgoing traffic, allow all.
   egress {
     protocol         = "-1"

--- a/modules/metric_ingestor/security_group.tf
+++ b/modules/metric_ingestor/security_group.tf
@@ -3,17 +3,6 @@ resource "aws_security_group" "main" {
   name   = "${var.environment}-${var.name}-sg"
   vpc_id = aws_vpc.main.id
 
-  # Allow port 22 for "ec2-instance-connect".
-  # This allows us to SSH into the hosts from the AWS Deveoper console.
-  # https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Connect-using-EC2-Instance-Connect.html
-  ingress {
-    protocol         = "tcp"
-    from_port        = 22
-    to_port          = 22
-    cidr_blocks      = ["0.0.0.0/0"]
-    ipv6_cidr_blocks = ["::/0"]
-  }
-
   # For outgoing traffic, allow all.
   egress {
     protocol         = "-1"


### PR DESCRIPTION
We've migrated from EC2 Instance Connect to Session Manager for remote management of metrics-ingestor to align with security best practises and eliminated open inbound ports, and cert management. tfsec code scanner [reports](https://github.com/dydxopsdao/v4-infrastructure/security/code-scanning) open ingress port 22 from /0 as CRITICAL severity

Quick facts:
- Session manager is a component of AWS systems manager.
- Requires no opening of inbound ports, no jump host, no SSH keys.
- Connect to ec2 via an interactive one-click browser-based aws console or through the AWS CLI.
- Centralized access management with IAM roles
- You need to grant AWS Systems Manager permission to perform actions on your instances. We grant permission, by giving the EC2 permission to assume an IAM service role that contains the `AmazonSSMManagedInstanceCore` an AWS managed policy.
- Session Manager requires ec2 to have ssm agent installed.
- Many ami come with ssm [pre-installed]( https://docs.aws.amazon.com/systems-manager/latest/userguide/ami-preinstalled-agent.html)

We would suggest adopting similar hardening for metric_ingestor and other v4 components.
