### PR TITLE
Allow to enable/disable multi_az option on master node and remove read_replica_2 instance on dev*

### DIFF
--- a/indexer/rds.tf
+++ b/indexer/rds.tf
@@ -215,7 +215,7 @@ resource "aws_db_instance" "main" {
   performance_insights_enabled          = true
   performance_insights_retention_period = 31
   auto_minor_version_upgrade            = false
-  multi_az                              = true
+  multi_az                              = var.enable_rds_main_multiaz
 
   tags = {
     Name        = local.aws_db_instance_main_name
@@ -250,6 +250,7 @@ resource "aws_db_instance" "read_replica" {
 
 # Read replica 2
 resource "aws_db_instance" "read_replica_2" {
+  count          = var.create_read_replica_2 ? 1 : 0
   identifier     = "${local.aws_db_instance_main_name}-read-replica-2"
   instance_class = var.rds_db_instance_class
   # engine, engine_version, name, username, db_subnet_group_name, allocated_storage do not have to

--- a/indexer/route53.tf
+++ b/indexer/route53.tf
@@ -19,11 +19,12 @@ resource "aws_route53_record" "read_replica_1" {
 }
 
 resource "aws_route53_record" "read_replica_2" {
+  count   = var.create_read_replica_2 ? 1 : 0
   zone_id = aws_route53_zone.main.zone_id
   name    = "postgres-main-rr.dydx-indexer.private"
   type    = "CNAME"
   ttl     = "30"
-  records = ["${aws_db_instance.read_replica_2.address}"]
+  records = ["${aws_db_instance.read_replica_2[count.index].address}"]
   weighted_routing_policy {
     weight = 1
   }

--- a/indexer/variables.tf
+++ b/indexer/variables.tf
@@ -472,3 +472,15 @@ variable "image_count" {
   description = "Number of images to store for ECR, defaults to 100."
   default     = 100
 }
+
+variable "create_read_replica_2" {
+  description = "Create read replia 2 or not. Default: true"
+  type        = bool
+  default     = true
+}
+
+variable "enable_rds_main_multiaz" {
+  description = "Enable RDS main instance. Default: true"
+  type        = bool
+  default     = true
+}


### PR DESCRIPTION
Support:
- multi_az on RDS master node
- read_replica_2 instance

With `enable_rds_main_multiaz` = true and `create_read_replica_2` = true (default values that works for mainnet, testnet ), this requires changes in state due to index. No new resources are created or deleted. Plan is below 
```
  # aws_db_instance.read_replica_2 has moved to aws_db_instance.read_replica_2[0]
    resource "aws_db_instance" "read_replica_2" {
        id                                    = "dev*-indexer-apne1-db-read-replica-2"
        name                                  = "dydx"
        tags                                  = {
            "Environment" = "dev*"
            "Name"        = "dev*-indexer-apne1-db-read-replica-2"
        }
        # (52 unchanged attributes hidden)
    }

  # aws_route53_record.read_replica_2 has moved to aws_route53_record.read_replica_2[0]
    resource "aws_route53_record" "read_replica_2" {
        id                               = "***"
        name                             = "postgres-main-rr.dydx-indexer.private"
        # (7 unchanged attributes hidden)

        # (1 unchanged block hidden)
    }
```

With `enable_rds_main_multiaz` = false and `create_read_replica_2` = false, this will delete read_replica_2 instance + route53 records and changes multi_az option. Plan is below
```
~ resource "aws_db_instance" "main" {
        id                                    = "dev*-indexer-apne1-db"
      ~ multi_az                              = true -> false
        name                                  = "dydx"
        tags                                  = {
            "Environment" = "dev*"
            "Name"        = "dev*-indexer-apne1-db"
        }
        # (63 unchanged attributes hidden)
    }

  # aws_db_instance.read_replica_2[0] will be destroyed
  # (because index [0] is out of range for count)
  # (moved from aws_db_instance.read_replica_2)
  - resource "aws_db_instance" "read_replica_2" {
   .......
   }
```
