### PR TITLE
upgrade kafka version and reduce session timeout

### DIFF
--- a/indexer/locals.tf
+++ b/indexer/locals.tf
@@ -1,5 +1,5 @@
 locals {
-  kafka_version = "2.6.2"
+  kafka_version = "3.4.0"
   rds_db_name   = "dydx"
   rds_username  = "dydx"
   rds_port      = 5432

--- a/indexer/msk.tf
+++ b/indexer/msk.tf
@@ -16,7 +16,7 @@ resource "aws_msk_configuration" "main" {
   replica.fetch.max.bytes=4194304
   message.max.bytes=4194304
   unclean.leader.election.enable=true
-  zookeeper.session.timeout.ms=18000
+  zookeeper.session.timeout.ms=6000
   PROPERTIES
 }
 


### PR DESCRIPTION
current kafka verion will become deprecated 
reduce session timeout to streamline new lead broker election