### PR TITLE
Allow to enable/disable multi_az option on master node and remove read_replica_2 instance on dev*

### DIFF
--- a/indexer/rds.tf
+++ b/indexer/rds.tf
@@ -215,7 +215,7 @@ resource "aws_db_instance" "main" {
   performance_insights_enabled          = true
   performance_insights_retention_period = 31
   auto_minor_version_upgrade            = false
-  multi_az                              = true
+  multi_az                              = var.enable_rds_main_multiaz
 
   tags = {
     Name        = local.aws_db_instance_main_name
@@ -250,6 +250,7 @@ resource "aws_db_instance" "read_replica" {
 
 # Read replica 2
 resource "aws_db_instance" "read_replica_2" {
+  count          = var.create_read_replica_2 ? 1 : 0
   identifier     = "${local.aws_db_instance_main_name}-read-replica-2"
   instance_class = var.rds_db_instance_class
   # engine, engine_version, name, username, db_subnet_group_name, allocated_storage do not have to

--- a/indexer/route53.tf
+++ b/indexer/route53.tf
@@ -19,11 +19,12 @@ resource "aws_route53_record" "read_replica_1" {
 }
 
 resource "aws_route53_record" "read_replica_2" {
+  count   = var.create_read_replica_2 ? 1 : 0
   zone_id = aws_route53_zone.main.zone_id
   name    = "postgres-main-rr.dydx-indexer.private"
   type    = "CNAME"
   ttl     = "30"
-  records = ["${aws_db_instance.read_replica_2.address}"]
+  records = ["${aws_db_instance.read_replica_2[count.index].address}"]
   weighted_routing_policy {
     weight = 1
   }

--- a/indexer/variables.tf
+++ b/indexer/variables.tf
@@ -508,3 +508,15 @@ variable "s3_load_balancer_logs_expiration_days" {
   description = "Number of days to store load balancer logs on S3, defaults to 31."
   default     = 31
 }
+
+variable "create_read_replica_2" {
+  description = "Create read replia 2 or not. Default: true"
+  type        = bool
+  default     = true
+}
+
+variable "enable_rds_main_multiaz" {
+  description = "Enable RDS main instance. Default: true"
+  type        = bool
+  default     = true
+}


### PR DESCRIPTION
Allow to enable/disable:
- multi_az on RDS master node
- read_replica_2 instance

With enable_rds_main_multiaz = true and create_read_replica_2 = true (default values that works for mainnet, testnet ), this requires changes in state due to index. No new resources are created or deleted. 