### PR TITLE
Set assign_public_ip = false as all the tasks are in private subnet

### DIFF
--- a/indexer/ecs.tf
+++ b/indexer/ecs.tf
@@ -50,7 +50,7 @@ resource "aws_ecs_service" "main" {
       aws_subnet.private_subnets[subnet_name].id
     ] : [for subnet in aws_subnet.private_subnets : subnet.id]
     security_groups  = [aws_security_group.services[each.key].id]
-    assign_public_ip = true
+    assign_public_ip = false
   }
 
   dynamic "load_balancer" {


### PR DESCRIPTION
Indexer ecs services  tasks are placed in private  subnet. All the external connection with be routed throught NAT Gateway.
Therefore, set assign_public_ip = false to avoid wasted public ip and cost. 