### PR TITLE
Allow to disable backup_full_node

### DIFF
--- a/indexer/backup_full_node_ap_northeast_1.tf
+++ b/indexer/backup_full_node_ap_northeast_1.tf
@@ -1,5 +1,6 @@
 module "backup_full_node_ap_northeast_1" {
   source = "../modules/validator"
+  count  = var.create_backup_full_node ? 1 : 0
 
   environment = var.environment
 
@@ -44,4 +45,9 @@ module "backup_full_node_ap_northeast_1" {
   providers = {
     aws = aws.ap_northeast_1
   }
+}
+
+moved {
+  from = module.backup_full_node_ap_northeast_1
+  to   = module.backup_full_node_ap_northeast_1[0]
 }

--- a/indexer/route_table.tf
+++ b/indexer/route_table.tf
@@ -68,9 +68,10 @@ resource "aws_route" "full_node_route_to_indexer" {
 # NOTE: This is not an individual AWS resource, but rather an attachment to the route table, and so
 # no tags are added.
 resource "aws_route" "backup_full_node_route_to_indexer" {
-  route_table_id            = module.backup_full_node_ap_northeast_1.route_table_id
+  count                     = var.create_backup_full_node ? 1 : 0
+  route_table_id            = module.backup_full_node_ap_northeast_1[0].route_table_id
   destination_cidr_block    = var.indexers[var.region].vpc_cidr_block
-  vpc_peering_connection_id = aws_vpc_peering_connection.backup_full_node_peer.id
+  vpc_peering_connection_id = aws_vpc_peering_connection.backup_full_node_peer[0].id
 }
 
 # Route from the Indexer's private subnets to the full node's VPC. Needed so that the full node can
@@ -88,9 +89,9 @@ resource "aws_route" "indexer_route_to_full_node" {
 }
 
 resource "aws_route" "indexer_route_to_backup_full_node" {
-  for_each = aws_route_table.private
+  for_each = var.create_backup_full_node ? aws_route_table.private : {}
 
   route_table_id            = each.value.id
   destination_cidr_block    = var.backup_full_node_cidr_vpc
-  vpc_peering_connection_id = aws_vpc_peering_connection.backup_full_node_peer.id
+  vpc_peering_connection_id = aws_vpc_peering_connection.backup_full_node_peer[0].id
 }

--- a/indexer/security_group.tf
+++ b/indexer/security_group.tf
@@ -62,7 +62,7 @@ resource "aws_security_group" "msk" {
     security_groups = flatten([
       aws_security_group.devbox.id,
       module.full_node_ap_northeast_1.aws_security_group_id,
-      module.backup_full_node_ap_northeast_1.aws_security_group_id,
+      var.create_backup_full_node ? [module.backup_full_node_ap_northeast_1[0].aws_security_group_id] : [],
       # Lambda Services
       [
         for service in keys(local.lambda_services) :

--- a/indexer/variables.tf
+++ b/indexer/variables.tf
@@ -572,3 +572,8 @@ variable "lambda_cpu_architecture" {
   }
 }
 
+variable "create_backup_full_node" {
+  description = "Create backup full node. Default: true for mainnet, testnet"
+  type        = bool
+  default     = true
+}

--- a/indexer/vpc.tf
+++ b/indexer/vpc.tf
@@ -84,8 +84,9 @@ resource "aws_vpc_peering_connection" "full_node_peer" {
 }
 
 resource "aws_vpc_peering_connection" "backup_full_node_peer" {
+  count       = var.create_backup_full_node ? 1 : 0
   peer_vpc_id = aws_vpc.main.id
-  vpc_id      = module.backup_full_node_ap_northeast_1.aws_vpc_id
+  vpc_id      = module.backup_full_node_ap_northeast_1[0].aws_vpc_id
   # Auto-accept allows the VPC peering connection to be made programmatically with no manual steps
   # to accept the VPC peering connection in the console
   # This can only be done if both VPCs are in the same region and AWS account (which they are)


### PR DESCRIPTION
New variable create_backup_full_node to allow disable backup_full_node
Default: true
Note that even with true, state needs to be changed as the index of `module.backup_full_node_ap_northeast_1` has become `module.backup_full_node_ap_northeast_1[0]`. And state migration happens automatically by moved block