### PR TITLE
Remove option to create load balancer without HTTPS option.

### DIFF
--- a/indexer/acm.tf
+++ b/indexer/acm.tf
@@ -1,6 +1,6 @@
-# Certificate for HTTPS listener on the load balancer - only created if `var.enable_https` is true
+# Certificate for HTTPS listener on the load balancer
 resource "aws_acm_certificate" "cert" {
-  count             = var.enable_https ? 1 : 0
+  count             = 1
   domain_name       = var.acm_certificate_domain
   validation_method = "DNS"
 

--- a/indexer/load_balancer.tf
+++ b/indexer/load_balancer.tf
@@ -36,10 +36,9 @@ resource "aws_lb_listener" "public_http" {
   }
 }
 
-# HTTPS listener - only created if `var.enable_https` is true
 # Returns 404 by default
 resource "aws_lb_listener" "public_https" {
-  count             = var.enable_https ? 1 : 0
+  count             = 1
   load_balancer_arn = aws_lb.public.arn
   certificate_arn   = aws_acm_certificate.cert[0].arn
   port              = "443"
@@ -98,11 +97,9 @@ resource "aws_lb_listener_rule" "public_http_comlink" {
   }
 }
 
-# HTTPS rules - only created if `var.enable_https` is true
-
 # Load balancer rule to redirect all `/v4/ws` paths to socks. ws = websockets
 resource "aws_lb_listener_rule" "public_https_socks" {
-  count        = var.enable_https ? 1 : 0
+  count        = 1
   listener_arn = aws_lb_listener.public_https[0].arn
   priority     = 20
 
@@ -120,7 +117,7 @@ resource "aws_lb_listener_rule" "public_https_socks" {
 
 # Load balancer rule to redirect all `/v4/*` paths to comlink
 resource "aws_lb_listener_rule" "public_https_comlink" {
-  count        = var.enable_https ? 1 : 0
+  count        = 1
   listener_arn = aws_lb_listener.public_https[0].arn
   priority     = 30
 

--- a/indexer/security_group.tf
+++ b/indexer/security_group.tf
@@ -276,9 +276,9 @@ resource "aws_security_group_rule" "inbound_http_to_load_balancer" {
   ipv6_cidr_blocks  = ["::/0"]
 }
 
-# Ingress rule for HTTP traffic for the load balancer - - only created if `var.enable_https` is true
+# Ingress rule for HTTP traffic for the load balancer
 resource "aws_security_group_rule" "inbound_https_to_load_balancer" {
-  count             = var.public_access && var.enable_https ? 1 : 0
+  count             = var.public_access ? 1 : 0
   security_group_id = aws_security_group.load_balancer_public.id
   type              = "ingress"
   from_port         = 443

--- a/indexer/variables.tf
+++ b/indexer/variables.tf
@@ -284,11 +284,6 @@ variable "datadog_api_key" {
   sensitive   = true
 }
 
-variable "enable_https" {
-  type        = bool
-  description = "Whether to enable HTTPS for connecting to the indexer"
-}
-
 variable "acm_certificate_domain" {
   type        = string
   description = "Domain for ACM certificate if HTTPS is enabled"


### PR DESCRIPTION
This load balancer is public facing, general best practice is to default to HTTPS since HTTP is not encrypted