### PR TITLE
Update postgres to 16.8. Imperator & mainnet is running 16.8 so we should match in testing environments

### DIFF
--- a/indexer/rds.tf
+++ b/indexer/rds.tf
@@ -1,6 +1,6 @@
 locals {
   db_engine         = "postgres"
-  db_engine_version = "12.22"
+  db_engine_version = "16.8"
 }
 
 # Subnets to associate with the RDS instance.


### PR DESCRIPTION
Testnet is already at 17.4, expected no-op
Staging is on 16.8 - expected no-op
Imperator is on 16.8 - expected no-op
Mainnet Internal is on 16.8 - expected no-op
Dev is on 12.22 - expected upgrade