### PR TITLE
Update parameter group to postgres16.

### DIFF
--- a/indexer/rds.tf
+++ b/indexer/rds.tf
@@ -20,7 +20,7 @@ resource "aws_db_subnet_group" "main" {
 # instance.
 resource "aws_db_parameter_group" "main" {
   name   = "${var.environment}-${var.indexers[var.region].name}-db-parameter-group"
-  family = "postgres12"
+  family = "postgres16"
 
   # Matches v3.
   # Logs each successful connection.


### PR DESCRIPTION
 This is required for the postgres upgrade.

This is only for dev environments. All production environments are already on postgres 16.8+ and this is a no-op