### PR TITLE
Set force_ssl default to false for RDS param groups

### DIFF
--- a/indexer/rds.tf
+++ b/indexer/rds.tf
@@ -181,7 +181,7 @@ resource "aws_db_parameter_group" "main" {
   # Set force_ssl to false, indexer jobs do not set SSL for database connections
   # by setting this to true, our indexer jobs will crash loop.
   parameter {
-    name = "rds.force_ssl"
+    name  = "rds.force_ssl"
     value = "0" # Default is true
   }
 

--- a/indexer/rds.tf
+++ b/indexer/rds.tf
@@ -178,9 +178,11 @@ resource "aws_db_parameter_group" "main" {
     value = "1" # Default is false (disabled).
   }
 
+  # Set force_ssl to false, indexer jobs do not set SSL for database connections
+  # by setting this to true, our indexer jobs will crash loop.
   parameter {
     name = "rds.force_ssl"
-    value = "0" # Default is true, we don't force SSL
+    value = "0" # Default is true
   }
 
   tags = {

--- a/indexer/rds.tf
+++ b/indexer/rds.tf
@@ -178,6 +178,11 @@ resource "aws_db_parameter_group" "main" {
     value = "1" # Default is false (disabled).
   }
 
+  parameter {
+    name = "rds.force_ssl"
+    value = "0" # Default is true, we don't force SSL
+  }
+
   tags = {
     Name        = "${var.environment}-${var.indexers[var.region].name}-db-parameter-group"
     Environment = var.environment


### PR DESCRIPTION
This can potentially cause an outage because we do set SSL to true in our indexer jobs