### PR TITLE
security(github): add CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,6 @@
-* @jiajames @vincentwschau @Christopher-Li @lucas-dydx
+# repo default
+* @dydxprotocol/infrastructure-code-owners
+
+# global security policy
+/.github/   @dydxprotocol/security
+/CODEOWNERS @dydxprotocol/security


### PR DESCRIPTION
## Summary
- Replace individual repo-wide CODEOWNERS with @dydxprotocol/infrastructure-code-owners.
- Add @dydxprotocol/security as code owners for .github/ and the CODEOWNERS file.
- Align repository ownership with org-level team governance and security policy.

## Details
- Repo governance:
  - Default rule: `*` now maps to the infra team for broad ownership.
  - Path-specific overrides:
    - `/.github/` owned by the security team to govern workflows, policies, and templates.
    - `/CODEOWNERS` owned by the security team to control future ownership changes.

## Risk & Impact
- Low risk: metadata-only change affecting reviewer assignment and required approvals.
- Potential behavior change: PRs touching .github/ or CODEOWNERS will require security team review if branch protection enforces CODEOWNERS.

## Testing
- No tests applicable; relies on GitHub CODEOWNERS behavior.

## Reviewer Notes
- Verify team slugs (@dydxprotocol/infrastructure-code-owners, @dydxprotocol/security) exist and have repo access.
- Confirm branch protection rules require CODEOWNERS review where intended.