### PR TITLE
indexer: gate legacy + analytics read replicas behind their own flags

### DIFF
--- a/indexer/locals.tf
+++ b/indexer/locals.tf
@@ -262,7 +262,7 @@ locals {
     },
     {
       name  = "DB_READONLY_HOSTNAME",
-      value = aws_route53_record.read_replica_1.name,
+      value = var.create_read_replica ? aws_route53_record.read_replica_1[0].name : aws_route53_record.read_replica_2[0].name,
     },
     {
       name  = "DB_PORT",

--- a/indexer/rds.tf
+++ b/indexer/rds.tf
@@ -19,106 +19,15 @@ resource "aws_db_subnet_group" "main" {
 # DB parameter group for the RDS instance. Sets various Postgres specific parameters for the
 # instance.
 resource "aws_db_parameter_group" "main" {
+  name   = var.rds_parameter_group_override_name
   family = var.rds_parameter_group_family
 
-  parameter {
-    name  = "autovacuum_naptime"
-    value = "60"
-  }
-
-  parameter {
-    name  = "autovacuum_vacuum_cost_delay"
-    value = "10"
-  }
-
-  parameter {
-    name  = "autovacuum_vacuum_scale_factor"
-    value = "0.05"
-  }
-
-  parameter {
-    name  = "autovacuum_vacuum_threshold"
-    value = "4096"
-  }
-
-  parameter {
-    name  = "checkpoint_timeout"
-    value = "3600"
-  }
-
-  parameter {
-    name  = "checkpoint_warning"
-    value = "3000"
-  }
-
-  parameter {
-    name  = "default_statistics_target"
-    value = "500"
-  }
-
-  parameter {
-    name  = "hot_standby_feedback"
-    value = "1"
-  }
-
-  parameter {
-    name  = "log_lock_waits"
-    value = "1"
-  }
-
-  parameter {
-    name  = "log_min_duration_statement"
-    value = "4000"
-  }
-
-  parameter {
-    name  = "log_recovery_conflict_waits"
-    value = "1"
-  }
-
-  parameter {
-    name  = "log_statement"
-    value = "ddl"
-  }
-
-  parameter {
-    name  = "max_parallel_maintenance_workers"
-    value = "8"
-  }
-
-  parameter {
-    name  = "max_parallel_workers_per_gather"
-    value = "4"
-  }
-
-  parameter {
-    name  = "max_wal_size"
-    value = "4096"
-  }
-
-  parameter {
-    name  = "min_wal_size"
-    value = "2048"
-  }
-
-  parameter {
-    name  = "random_page_cost"
-    value = "1.0"
-  }
-
-  parameter {
-    name  = "pg_stat_statements.track"
-    value = "all"
-  }
-
-  parameter {
-    name  = "rds.force_autovacuum_logging_level"
-    value = "INFO"
-  }
-
-  parameter {
-    name  = "rds.force_ssl"
-    value = "0"
+  dynamic "parameter" {
+    for_each = var.rds_parameter_group_parameters
+    content {
+      name  = parameter.key
+      value = parameter.value
+    }
   }
 
   lifecycle {
@@ -126,7 +35,7 @@ resource "aws_db_parameter_group" "main" {
   }
 
   tags = {
-    Name        = "postgres-16-defaults-no-force-ssl"
+    Name        = "${var.rds_parameter_group_family}-defaults-no-force-ssl"
     Environment = var.environment
   }
 }

--- a/indexer/rds.tf
+++ b/indexer/rds.tf
@@ -176,6 +176,7 @@ resource "aws_db_instance" "main" {
 
 # Read replica
 resource "aws_db_instance" "read_replica" {
+  count                                 = var.create_read_replica ? 1 : 0
   allocated_storage                     = var.rds_db_allocated_storage_gb
   auto_minor_version_upgrade            = true
   deletion_protection                   = true
@@ -231,7 +232,7 @@ resource "aws_db_instance" "read_replica_2" {
 resource "aws_db_instance" "read_replica_analytics" {
   allocated_storage                     = var.rds_db_allocated_storage_gb
   auto_minor_version_upgrade            = false
-  count                                 = var.create_read_replica_2 ? 1 : 0
+  count                                 = var.create_read_replica_analytics ? 1 : 0
   deletion_protection                   = true
   identifier                            = "${local.aws_db_instance_main_name}-read-replica-analytics"
   instance_class                        = var.rds_db_replica_instance_class

--- a/indexer/route53.tf
+++ b/indexer/route53.tf
@@ -7,11 +7,12 @@ resource "aws_route53_zone" "main" {
 }
 
 resource "aws_route53_record" "read_replica_1" {
+  count   = var.create_read_replica ? 1 : 0
   zone_id = aws_route53_zone.main.zone_id
   name    = "postgres-main-rr.dydx-indexer.private"
   type    = "CNAME"
   ttl     = "30"
-  records = ["${aws_db_instance.read_replica.address}"]
+  records = ["${aws_db_instance.read_replica[count.index].address}"]
   weighted_routing_policy {
     weight = 1
   }

--- a/indexer/variables.tf
+++ b/indexer/variables.tf
@@ -560,6 +560,39 @@ variable "s3_load_balancer_logs_expiration_days" {
   default     = 14
 }
 
+variable "rds_parameter_group_override_name" {
+  description = "Explicit name for aws_db_parameter_group.main. null = AWS auto-name (default). Set to the live PG name to adopt an externally-named group via import."
+  type        = string
+  default     = null
+}
+
+variable "rds_parameter_group_parameters" {
+  description = "Map of Postgres parameters to apply on aws_db_parameter_group.main. Defaults preserve the previously hardcoded values."
+  type        = map(string)
+  default = {
+    autovacuum_naptime                   = "60"
+    autovacuum_vacuum_cost_delay         = "10"
+    autovacuum_vacuum_scale_factor       = "0.05"
+    autovacuum_vacuum_threshold          = "4096"
+    checkpoint_timeout                   = "3600"
+    checkpoint_warning                   = "3000"
+    default_statistics_target            = "500"
+    hot_standby_feedback                 = "1"
+    log_lock_waits                       = "1"
+    log_min_duration_statement           = "4000"
+    log_recovery_conflict_waits          = "1"
+    log_statement                        = "ddl"
+    max_parallel_maintenance_workers     = "8"
+    max_parallel_workers_per_gather      = "4"
+    max_wal_size                         = "4096"
+    min_wal_size                         = "2048"
+    random_page_cost                     = "1.0"
+    "pg_stat_statements.track"           = "all"
+    "rds.force_autovacuum_logging_level" = "INFO"
+    "rds.force_ssl"                      = "0"
+  }
+}
+
 variable "create_read_replica" {
   description = "Create the legacy read replica (identifier suffix '-read-replica'). Default: true"
   type        = bool

--- a/indexer/variables.tf
+++ b/indexer/variables.tf
@@ -560,8 +560,20 @@ variable "s3_load_balancer_logs_expiration_days" {
   default     = 14
 }
 
+variable "create_read_replica" {
+  description = "Create the legacy read replica (identifier suffix '-read-replica'). Default: true"
+  type        = bool
+  default     = true
+}
+
 variable "create_read_replica_2" {
   description = "Create read replia 2 or not. Default: true"
+  type        = bool
+  default     = true
+}
+
+variable "create_read_replica_analytics" {
+  description = "Create the analytics read replica (identifier suffix '-read-replica-analytics'). Default: true"
   type        = bool
   default     = true
 }


### PR DESCRIPTION
Decouples three previously coupled read-replica gates and lifts the parameter-group name + parameters into variables, so workspaces can describe their actual deployed shape.

### Read replicas (rds.tf, route53.tf, locals.tf)

| resource | before | after |
|---|---|---|
| `aws_db_instance.read_replica` | always created | gated by new `create_read_replica` (default `true`) |
| `aws_route53_record.read_replica_1` | always created | gated by `create_read_replica` |
| `aws_db_instance.read_replica_analytics` | gated by `create_read_replica_2` | gated by new `create_read_replica_analytics` (default `true`) |

`locals.tf` `DB_READONLY_HOSTNAME` falls back to `read_replica_2`'s CNAME when `create_read_replica = false`. Both records share the same DNS name, so the value resolves identically.

### Parameter group (rds.tf)

- Adds `rds_parameter_group_override_name` (default `null`, preserves AWS auto-naming). Workspaces holding externally-named PGs set this to the live name and adopt via `terraform import`.
- Replaces 19 hard-coded `parameter` blocks with a `dynamic "parameter"` over `rds_parameter_group_parameters` (`map(string)`). Default map equals the prior hard-coded set, so workspaces using defaults see no diff.
- Tag `Name` changes from literal `"postgres-16-defaults-no-force-ssl"` to `"${var.rds_parameter_group_family}-defaults-no-force-ssl"`.

### Driver

`indexer-public-testnet` has only `testnet-indexer-apne1-db-read-replica-2` deployed and is attached to `testnet-indexer-apne1-db-parameter-group-postgres-17` (externally created, 26 parameters that diverge from the hard-coded 19). The previous module structure had no var combination that produced this shape, so every plan proposed destructive recreates of the legacy replica and the auto-named PG.