### PR TITLE
indexer: add indexer_enabled teardown gate for internal-mainnet wind-down

### DIFF
--- a/indexer/acm.tf
+++ b/indexer/acm.tf
@@ -1,6 +1,6 @@
 # Certificate for HTTPS listener on the load balancer
 resource "aws_acm_certificate" "cert" {
-  count             = 1
+  count             = var.indexer_enabled ? 1 : 0
   domain_name       = var.acm_certificate_domain
   validation_method = "DNS"
 
@@ -10,6 +10,6 @@ resource "aws_acm_certificate" "cert" {
   }
 
   lifecycle {
-    prevent_destroy = true
+    prevent_destroy = false
   }
 }

--- a/indexer/acm.tf
+++ b/indexer/acm.tf
@@ -1,6 +1,6 @@
 # Certificate for HTTPS listener on the load balancer
 resource "aws_acm_certificate" "cert" {
-  count             = var.indexer_enabled ? 1 : 0
+  count             = local.indexer_enabled ? 1 : 0
   domain_name       = var.acm_certificate_domain
   validation_method = "DNS"
 

--- a/indexer/athena.tf
+++ b/indexer/athena.tf
@@ -1,3 +1,4 @@
 resource "aws_glue_catalog_database" "rds_snapshots" {
-  name = "rds_snapshots"
+  count = var.indexer_enabled ? 1 : 0
+  name  = "rds_snapshots"
 }

--- a/indexer/athena.tf
+++ b/indexer/athena.tf
@@ -1,4 +1,4 @@
 resource "aws_glue_catalog_database" "rds_snapshots" {
-  count = var.indexer_enabled ? 1 : 0
+  count = local.indexer_enabled ? 1 : 0
   name  = "rds_snapshots"
 }

--- a/indexer/backup_full_node_ap_northeast_1.tf
+++ b/indexer/backup_full_node_ap_northeast_1.tf
@@ -1,6 +1,6 @@
 module "backup_full_node_ap_northeast_1" {
   source = "../modules/validator"
-  count  = var.indexer_enabled && var.create_backup_full_node ? 1 : 0
+  count  = local.indexer_enabled && var.create_backup_full_node ? 1 : 0
 
   environment = var.environment
 

--- a/indexer/backup_full_node_ap_northeast_1.tf
+++ b/indexer/backup_full_node_ap_northeast_1.tf
@@ -1,6 +1,6 @@
 module "backup_full_node_ap_northeast_1" {
   source = "../modules/validator"
-  count  = var.create_backup_full_node ? 1 : 0
+  count  = var.indexer_enabled && var.create_backup_full_node ? 1 : 0
 
   environment = var.environment
 
@@ -22,7 +22,7 @@ module "backup_full_node_ap_northeast_1" {
   container_chain_home                   = var.full_node_container_chain_home
   container_p2p_persistent_peers         = join(",", var.full_node_container_p2p_persistent_peers)
   container_optimistic_execution_enabled = var.full_node_container_optimistic_execution_enabled
-  container_kafka_conn_str               = aws_msk_cluster.main.bootstrap_brokers
+  container_kafka_conn_str               = aws_msk_cluster.main[0].bootstrap_brokers
   container_non_validating_full_node     = true
   full_node_send_off_chain_messages      = false
 

--- a/indexer/datadog.tf
+++ b/indexer/datadog.tf
@@ -1,5 +1,5 @@
 module "datadog_agent" {
-  count  = var.indexer_enabled ? 1 : 0
+  count  = local.indexer_enabled ? 1 : 0
   source = "../modules/datadog_agent"
 
   env             = var.environment
@@ -41,7 +41,7 @@ module "datadog_log_fowarder_indexer_lambda_services" {
 
 // Datadog log forwarder for s3 logs
 resource "aws_cloudformation_stack" "datadog_forwarder" {
-  count        = var.indexer_enabled ? 1 : 0
+  count        = local.indexer_enabled ? 1 : 0
   name         = "datadog-log-forwarder"
   capabilities = ["CAPABILITY_IAM", "CAPABILITY_NAMED_IAM", "CAPABILITY_AUTO_EXPAND"]
   parameters = {

--- a/indexer/datadog.tf
+++ b/indexer/datadog.tf
@@ -1,4 +1,5 @@
 module "datadog_agent" {
+  count  = var.indexer_enabled ? 1 : 0
   source = "../modules/datadog_agent"
 
   env             = var.environment
@@ -40,6 +41,7 @@ module "datadog_log_fowarder_indexer_lambda_services" {
 
 // Datadog log forwarder for s3 logs
 resource "aws_cloudformation_stack" "datadog_forwarder" {
+  count        = var.indexer_enabled ? 1 : 0
   name         = "datadog-log-forwarder"
   capabilities = ["CAPABILITY_IAM", "CAPABILITY_NAMED_IAM", "CAPABILITY_AUTO_EXPAND"]
   parameters = {

--- a/indexer/ecs.tf
+++ b/indexer/ecs.tf
@@ -1,6 +1,7 @@
 # ECS Cluster for the indexer.
 resource "aws_ecs_cluster" "main" {
-  name = "${var.environment}-${var.indexers[var.region].name}-cluster"
+  count = var.indexer_enabled ? 1 : 0
+  name  = "${var.environment}-${var.indexers[var.region].name}-cluster"
 
   tags = {
     Name        = "${var.environment}-${var.indexers[var.region].name}-cluster"
@@ -31,7 +32,7 @@ resource "aws_ecs_service" "main" {
   for_each = local.services
 
   name                = "${var.environment}-${var.indexers[var.region].name}-${each.key}"
-  cluster             = aws_ecs_cluster.main.id
+  cluster             = aws_ecs_cluster.main[0].id
   task_definition     = aws_ecs_task_definition.main[each.key].arn
   desired_count       = each.value.ecs_desired_count
   launch_type         = "FARGATE"
@@ -109,8 +110,8 @@ resource "aws_ecs_task_definition" "main" {
             mode                  = "non-blocking"
           }
         }
-        cpu               = each.value.task_definition_cpu - module.datadog_agent.datadog_cpu
-        memoryReservation = each.value.task_definition_memory - module.datadog_agent.datadog_memory
+        cpu               = each.value.task_definition_cpu - module.datadog_agent[0].datadog_cpu
+        memoryReservation = each.value.task_definition_memory - module.datadog_agent[0].datadog_memory
         portMappings = [
           for port in each.value.ports : {
             containerPort : port,
@@ -159,7 +160,7 @@ resource "aws_ecs_task_definition" "main" {
           ]
         ),
       },
-      module.datadog_agent.ecs_fargate_container_definition
+      module.datadog_agent[0].ecs_fargate_container_definition
     ]
   )
 

--- a/indexer/ecs.tf
+++ b/indexer/ecs.tf
@@ -1,6 +1,6 @@
 # ECS Cluster for the indexer.
 resource "aws_ecs_cluster" "main" {
-  count = var.indexer_enabled ? 1 : 0
+  count = local.indexer_enabled ? 1 : 0
   name  = "${var.environment}-${var.indexers[var.region].name}-cluster"
 
   tags = {

--- a/indexer/elasticache.tf
+++ b/indexer/elasticache.tf
@@ -1,4 +1,5 @@
 resource "aws_elasticache_subnet_group" "main" {
+  count      = var.indexer_enabled ? 1 : 0
   name       = "${var.environment}-${var.indexers[var.region].name}-elasticache-subnet-group"
   subnet_ids = [for subnet in aws_subnet.private_subnets : subnet.id]
 
@@ -10,6 +11,7 @@ resource "aws_elasticache_subnet_group" "main" {
 
 // Elasticache Redis for all caching and storage of indexer off chain data.
 resource "aws_elasticache_replication_group" "main" {
+  count                      = var.indexer_enabled ? 1 : 0
   automatic_failover_enabled = true
   multi_az_enabled           = true
   replication_group_id       = "${var.environment}-${var.indexers[var.region].name}-redis"
@@ -19,9 +21,9 @@ resource "aws_elasticache_replication_group" "main" {
   engine                     = "valkey"
   engine_version             = "8.0"
   parameter_group_name       = var.elasticache_redis_parameter_group_name
-  security_group_ids         = [aws_security_group.redis.id]
+  security_group_ids         = [aws_security_group.redis[0].id]
   port                       = 6379
-  subnet_group_name          = aws_elasticache_subnet_group.main.name
+  subnet_group_name          = aws_elasticache_subnet_group.main[0].name
 
   tags = {
     name        = "${var.environment}-${var.indexers[var.region].name}-redis"
@@ -29,11 +31,12 @@ resource "aws_elasticache_replication_group" "main" {
   }
 
   lifecycle {
-    prevent_destroy = true
+    prevent_destroy = false
   }
 }
 
 resource "aws_elasticache_subnet_group" "rate_limit" {
+  count      = var.indexer_enabled ? 1 : 0
   name       = "${var.environment}-${var.indexers[var.region].name}-elasticache-rate-limit-subnet-group"
   subnet_ids = [for subnet in aws_subnet.private_subnets : subnet.id]
 
@@ -45,6 +48,7 @@ resource "aws_elasticache_subnet_group" "rate_limit" {
 
 // Elasticache Redis for rate-limits
 resource "aws_elasticache_replication_group" "rate_limit" {
+  count                      = var.indexer_enabled ? 1 : 0
   automatic_failover_enabled = true
   multi_az_enabled           = true
   replication_group_id       = "${var.environment}-${var.indexers[var.region].name}-rate-limit-redis"
@@ -54,9 +58,9 @@ resource "aws_elasticache_replication_group" "rate_limit" {
   engine                     = "valkey"
   engine_version             = "8.0"
   parameter_group_name       = coalesce(var.elasticache_rate_limit_redis_parameter_group_name, var.elasticache_redis_parameter_group_name)
-  security_group_ids         = [aws_security_group.redis.id]
+  security_group_ids         = [aws_security_group.redis[0].id]
   port                       = 6379
-  subnet_group_name          = aws_elasticache_subnet_group.rate_limit.name
+  subnet_group_name          = aws_elasticache_subnet_group.rate_limit[0].name
 
   tags = {
     name        = "${var.environment}-${var.indexers[var.region].name}-rate-limit-redis"

--- a/indexer/elasticache.tf
+++ b/indexer/elasticache.tf
@@ -1,5 +1,5 @@
 resource "aws_elasticache_subnet_group" "main" {
-  count      = var.indexer_enabled ? 1 : 0
+  count      = local.indexer_enabled ? 1 : 0
   name       = "${var.environment}-${var.indexers[var.region].name}-elasticache-subnet-group"
   subnet_ids = [for subnet in aws_subnet.private_subnets : subnet.id]
 
@@ -11,7 +11,7 @@ resource "aws_elasticache_subnet_group" "main" {
 
 // Elasticache Redis for all caching and storage of indexer off chain data.
 resource "aws_elasticache_replication_group" "main" {
-  count                      = var.indexer_enabled ? 1 : 0
+  count                      = local.indexer_enabled ? 1 : 0
   automatic_failover_enabled = true
   multi_az_enabled           = true
   replication_group_id       = "${var.environment}-${var.indexers[var.region].name}-redis"
@@ -36,7 +36,7 @@ resource "aws_elasticache_replication_group" "main" {
 }
 
 resource "aws_elasticache_subnet_group" "rate_limit" {
-  count      = var.indexer_enabled ? 1 : 0
+  count      = local.indexer_enabled ? 1 : 0
   name       = "${var.environment}-${var.indexers[var.region].name}-elasticache-rate-limit-subnet-group"
   subnet_ids = [for subnet in aws_subnet.private_subnets : subnet.id]
 
@@ -48,7 +48,7 @@ resource "aws_elasticache_subnet_group" "rate_limit" {
 
 // Elasticache Redis for rate-limits
 resource "aws_elasticache_replication_group" "rate_limit" {
-  count                      = var.indexer_enabled ? 1 : 0
+  count                      = local.indexer_enabled ? 1 : 0
   automatic_failover_enabled = true
   multi_az_enabled           = true
   replication_group_id       = "${var.environment}-${var.indexers[var.region].name}-rate-limit-redis"

--- a/indexer/full_node_ap_northeast_1.tf
+++ b/indexer/full_node_ap_northeast_1.tf
@@ -1,5 +1,5 @@
 module "full_node_ap_northeast_1" {
-  count  = var.indexer_enabled ? 1 : 0
+  count  = local.indexer_enabled ? 1 : 0
   source = "../modules/validator"
 
   environment = var.environment

--- a/indexer/full_node_ap_northeast_1.tf
+++ b/indexer/full_node_ap_northeast_1.tf
@@ -1,4 +1,5 @@
 module "full_node_ap_northeast_1" {
+  count  = var.indexer_enabled ? 1 : 0
   source = "../modules/validator"
 
   environment = var.environment
@@ -21,7 +22,7 @@ module "full_node_ap_northeast_1" {
   container_chain_home                   = var.full_node_container_chain_home
   container_p2p_persistent_peers         = join(",", var.full_node_container_p2p_persistent_peers)
   container_optimistic_execution_enabled = var.full_node_container_optimistic_execution_enabled
-  container_kafka_conn_str               = aws_msk_cluster.main.bootstrap_brokers
+  container_kafka_conn_str               = aws_msk_cluster.main[0].bootstrap_brokers
   container_non_validating_full_node     = true
 
   datadog_api_key = var.datadog_api_key

--- a/indexer/iam.tf
+++ b/indexer/iam.tf
@@ -18,7 +18,7 @@ module "iam_service_ecs_task_roles" {
 // Legacy, delete after all environments have been migrated to using per task ECS roles.
 // Needed as existing running ECS tasks depend on this ECS role.
 module "iam_ecs_task_roles" {
-  count                         = var.indexer_enabled ? 1 : 0
+  count                         = local.indexer_enabled ? 1 : 0
   source                        = "../modules/iam/ecs_task_roles"
   name                          = var.indexers[var.region].name
   environment                   = var.environment
@@ -97,7 +97,7 @@ resource "aws_iam_role_policy_attachment" "lambda_services_upgrade_indexer_attac
 }
 
 resource "aws_iam_policy" "lambda_upgrade_indexer_policy" {
-  count       = var.indexer_enabled ? 1 : 0
+  count       = local.indexer_enabled ? 1 : 0
   name        = "UpdateIndexerPolicy"
   description = "Policy that grants permission necessary to upgrade indexer"
 

--- a/indexer/iam.tf
+++ b/indexer/iam.tf
@@ -18,6 +18,7 @@ module "iam_service_ecs_task_roles" {
 // Legacy, delete after all environments have been migrated to using per task ECS roles.
 // Needed as existing running ECS tasks depend on this ECS role.
 module "iam_ecs_task_roles" {
+  count                         = var.indexer_enabled ? 1 : 0
   source                        = "../modules/iam/ecs_task_roles"
   name                          = var.indexers[var.region].name
   environment                   = var.environment
@@ -92,10 +93,11 @@ resource "aws_iam_role_policy_attachment" "lambda_services_upgrade_indexer_attac
   for_each = { for key, value in local.lambda_services : key => value if value.requires_upgrade_indexer_iam_policies }
 
   role       = aws_iam_role.lambda_services[each.key].name
-  policy_arn = aws_iam_policy.lambda_upgrade_indexer_policy.arn
+  policy_arn = aws_iam_policy.lambda_upgrade_indexer_policy[0].arn
 }
 
 resource "aws_iam_policy" "lambda_upgrade_indexer_policy" {
+  count       = var.indexer_enabled ? 1 : 0
   name        = "UpdateIndexerPolicy"
   description = "Policy that grants permission necessary to upgrade indexer"
 

--- a/indexer/iam_github.tf
+++ b/indexer/iam_github.tf
@@ -1,4 +1,5 @@
 module "iam_github_actions" {
+  count       = var.indexer_enabled ? 1 : 0
   source      = "../modules/iam/github_actions_role"
   name        = var.indexers[var.region].name
   environment = var.environment

--- a/indexer/iam_github.tf
+++ b/indexer/iam_github.tf
@@ -1,5 +1,5 @@
 module "iam_github_actions" {
-  count       = var.indexer_enabled ? 1 : 0
+  count       = local.indexer_enabled ? 1 : 0
   source      = "../modules/iam/github_actions_role"
   name        = var.indexers[var.region].name
   environment = var.environment

--- a/indexer/indexer_monitors.tf
+++ b/indexer/indexer_monitors.tf
@@ -1,5 +1,5 @@
 module "indexer_monitors" {
-  count = var.indexer_enabled && var.enable_monitoring ? 1 : 0
+  count = local.indexer_enabled && var.enable_monitoring ? 1 : 0
 
   source                        = "../modules/indexer_monitors"
   env_tag                       = "v4-${var.environment}"

--- a/indexer/indexer_monitors.tf
+++ b/indexer/indexer_monitors.tf
@@ -1,5 +1,5 @@
 module "indexer_monitors" {
-  count = var.enable_monitoring ? 1 : 0
+  count = var.indexer_enabled && var.enable_monitoring ? 1 : 0
 
   source                        = "../modules/indexer_monitors"
   env_tag                       = "v4-${var.environment}"
@@ -8,7 +8,7 @@ module "indexer_monitors" {
   pagerduty_tag                 = var.monitoring_pagerduty_tag
   secondary_pagerduty_tag       = var.secondary_monitoring_pagerduty_tag
   ecs_cluster_name              = var.full_node_name
-  msk_cluster_name              = aws_msk_cluster.main.cluster_name
+  msk_cluster_name              = aws_msk_cluster.main[0].cluster_name
   team                          = var.monitoring_team
   url                           = var.indexer_url
   enable_precautionary_monitors = var.enable_precautionary_monitors

--- a/indexer/kms.tf
+++ b/indexer/kms.tf
@@ -13,7 +13,7 @@ data "aws_iam_policy_document" "kms_key_policy" {
 
 # KMS key for RDS export tasks.
 resource "aws_kms_key" "rds_export" {
-  count                   = var.indexer_enabled ? 1 : 0
+  count                   = local.indexer_enabled ? 1 : 0
   description             = "KMS key for RDS export tasks"
   deletion_window_in_days = 7
   policy                  = data.aws_iam_policy_document.kms_key_policy.json
@@ -22,7 +22,7 @@ resource "aws_kms_key" "rds_export" {
 # Policy document to allow ECS task role to use KMS key for RDS export tasks. Link to required
 # permissions: https://docs.aws.amazon.com/AmazonRDS/latest/APIReference/API_StartExportTask.html
 data "aws_iam_policy_document" "kms_permissions" {
-  count      = var.indexer_enabled ? 1 : 0
+  count      = local.indexer_enabled ? 1 : 0
   depends_on = [aws_kms_key.rds_export[0]]
 
   statement {
@@ -45,7 +45,7 @@ data "aws_iam_policy_document" "kms_permissions" {
 
 # IAM policy that will be attached to ECS task role to use KMS key for RDS export tasks.
 resource "aws_iam_policy" "kms_policy" {
-  count       = var.indexer_enabled ? 1 : 0
+  count       = local.indexer_enabled ? 1 : 0
   name        = "kmsPolicy"
   description = "A policy that provides KMS actions"
   policy      = data.aws_iam_policy_document.kms_permissions[0].json

--- a/indexer/kms.tf
+++ b/indexer/kms.tf
@@ -13,6 +13,7 @@ data "aws_iam_policy_document" "kms_key_policy" {
 
 # KMS key for RDS export tasks.
 resource "aws_kms_key" "rds_export" {
+  count                   = var.indexer_enabled ? 1 : 0
   description             = "KMS key for RDS export tasks"
   deletion_window_in_days = 7
   policy                  = data.aws_iam_policy_document.kms_key_policy.json
@@ -21,7 +22,8 @@ resource "aws_kms_key" "rds_export" {
 # Policy document to allow ECS task role to use KMS key for RDS export tasks. Link to required
 # permissions: https://docs.aws.amazon.com/AmazonRDS/latest/APIReference/API_StartExportTask.html
 data "aws_iam_policy_document" "kms_permissions" {
-  depends_on = [aws_kms_key.rds_export]
+  count      = var.indexer_enabled ? 1 : 0
+  depends_on = [aws_kms_key.rds_export[0]]
 
   statement {
     actions = [
@@ -37,13 +39,14 @@ data "aws_iam_policy_document" "kms_permissions" {
       "kms:RetireGrant",
     ]
 
-    resources = [aws_kms_key.rds_export.arn]
+    resources = [aws_kms_key.rds_export[0].arn]
   }
 }
 
 # IAM policy that will be attached to ECS task role to use KMS key for RDS export tasks.
 resource "aws_iam_policy" "kms_policy" {
+  count       = var.indexer_enabled ? 1 : 0
   name        = "kmsPolicy"
   description = "A policy that provides KMS actions"
-  policy      = data.aws_iam_policy_document.kms_permissions.json
+  policy      = data.aws_iam_policy_document.kms_permissions[0].json
 }

--- a/indexer/load_balancer.tf
+++ b/indexer/load_balancer.tf
@@ -1,6 +1,6 @@
 # Load balancer for all public services
 resource "aws_lb" "public" {
-  count              = var.indexer_enabled ? 1 : 0
+  count              = local.indexer_enabled ? 1 : 0
   name               = "${var.environment}-${var.indexers[var.region].name}-lb-public"
   load_balancer_type = "application"
   security_groups    = [aws_security_group.load_balancer_public[0].id]
@@ -23,7 +23,7 @@ resource "aws_lb" "public" {
 
 # Return 404 by default
 resource "aws_lb_listener" "public_http" {
-  count             = var.indexer_enabled ? 1 : 0
+  count             = local.indexer_enabled ? 1 : 0
   load_balancer_arn = aws_lb.public[0].arn
   port              = "80"
   protocol          = "HTTP"
@@ -40,7 +40,7 @@ resource "aws_lb_listener" "public_http" {
 
 # Returns 404 by default
 resource "aws_lb_listener" "public_https" {
-  count             = var.indexer_enabled ? 1 : 0
+  count             = local.indexer_enabled ? 1 : 0
   load_balancer_arn = aws_lb.public[0].arn
   certificate_arn   = aws_acm_certificate.cert[0].arn
   port              = "443"
@@ -67,7 +67,7 @@ resource "aws_lb_listener" "public_https" {
 # HTTP rules
 
 resource "aws_lb_listener_rule" "public_http_socks" {
-  count        = var.indexer_enabled ? 1 : 0
+  count        = local.indexer_enabled ? 1 : 0
   listener_arn = aws_lb_listener.public_http[0].arn
   priority     = 20
 
@@ -85,7 +85,7 @@ resource "aws_lb_listener_rule" "public_http_socks" {
 
 # Load balancer rule to redirect all `/v4/*` paths to comlink
 resource "aws_lb_listener_rule" "public_http_comlink" {
-  count        = var.indexer_enabled ? 1 : 0
+  count        = local.indexer_enabled ? 1 : 0
   listener_arn = aws_lb_listener.public_http[0].arn
   priority     = 30
 
@@ -103,7 +103,7 @@ resource "aws_lb_listener_rule" "public_http_comlink" {
 
 # Load balancer rule to redirect all `/v4/ws` paths to socks. ws = websockets
 resource "aws_lb_listener_rule" "public_https_socks" {
-  count        = var.indexer_enabled ? 1 : 0
+  count        = local.indexer_enabled ? 1 : 0
   listener_arn = aws_lb_listener.public_https[0].arn
   priority     = 20
 
@@ -121,7 +121,7 @@ resource "aws_lb_listener_rule" "public_https_socks" {
 
 # Load balancer rule to redirect all `/v4/*` paths to comlink
 resource "aws_lb_listener_rule" "public_https_comlink" {
-  count        = var.indexer_enabled ? 1 : 0
+  count        = local.indexer_enabled ? 1 : 0
   listener_arn = aws_lb_listener.public_https[0].arn
   priority     = 30
 

--- a/indexer/load_balancer.tf
+++ b/indexer/load_balancer.tf
@@ -1,13 +1,14 @@
 # Load balancer for all public services
 resource "aws_lb" "public" {
+  count              = var.indexer_enabled ? 1 : 0
   name               = "${var.environment}-${var.indexers[var.region].name}-lb-public"
   load_balancer_type = "application"
-  security_groups    = [aws_security_group.load_balancer_public.id]
+  security_groups    = [aws_security_group.load_balancer_public[0].id]
   subnets            = [for subnet in aws_subnet.public_subnets : subnet.id]
   ip_address_type    = "ipv4"
 
   access_logs {
-    bucket  = aws_s3_bucket.load_balancer.bucket
+    bucket  = aws_s3_bucket.load_balancer[0].bucket
     prefix  = "public"
     enabled = "true"
   }
@@ -17,12 +18,13 @@ resource "aws_lb" "public" {
     Environment = var.environment
   }
 
-  depends_on = [aws_internet_gateway.main]
+  depends_on = [aws_internet_gateway.main[0]]
 }
 
 # Return 404 by default
 resource "aws_lb_listener" "public_http" {
-  load_balancer_arn = aws_lb.public.arn
+  count             = var.indexer_enabled ? 1 : 0
+  load_balancer_arn = aws_lb.public[0].arn
   port              = "80"
   protocol          = "HTTP"
 
@@ -38,8 +40,8 @@ resource "aws_lb_listener" "public_http" {
 
 # Returns 404 by default
 resource "aws_lb_listener" "public_https" {
-  count             = 1
-  load_balancer_arn = aws_lb.public.arn
+  count             = var.indexer_enabled ? 1 : 0
+  load_balancer_arn = aws_lb.public[0].arn
   certificate_arn   = aws_acm_certificate.cert[0].arn
   port              = "443"
   protocol          = "HTTPS"
@@ -65,7 +67,8 @@ resource "aws_lb_listener" "public_https" {
 # HTTP rules
 
 resource "aws_lb_listener_rule" "public_http_socks" {
-  listener_arn = aws_lb_listener.public_http.arn
+  count        = var.indexer_enabled ? 1 : 0
+  listener_arn = aws_lb_listener.public_http[0].arn
   priority     = 20
 
   action {
@@ -82,7 +85,8 @@ resource "aws_lb_listener_rule" "public_http_socks" {
 
 # Load balancer rule to redirect all `/v4/*` paths to comlink
 resource "aws_lb_listener_rule" "public_http_comlink" {
-  listener_arn = aws_lb_listener.public_http.arn
+  count        = var.indexer_enabled ? 1 : 0
+  listener_arn = aws_lb_listener.public_http[0].arn
   priority     = 30
 
   action {
@@ -99,7 +103,7 @@ resource "aws_lb_listener_rule" "public_http_comlink" {
 
 # Load balancer rule to redirect all `/v4/ws` paths to socks. ws = websockets
 resource "aws_lb_listener_rule" "public_https_socks" {
-  count        = 1
+  count        = var.indexer_enabled ? 1 : 0
   listener_arn = aws_lb_listener.public_https[0].arn
   priority     = 20
 
@@ -117,7 +121,7 @@ resource "aws_lb_listener_rule" "public_https_socks" {
 
 # Load balancer rule to redirect all `/v4/*` paths to comlink
 resource "aws_lb_listener_rule" "public_https_comlink" {
-  count        = 1
+  count        = var.indexer_enabled ? 1 : 0
   listener_arn = aws_lb_listener.public_https[0].arn
   priority     = 30
 
@@ -141,7 +145,7 @@ resource "aws_lb_target_group" "services" {
   port        = 80
   protocol    = "HTTP"
   target_type = "ip"
-  vpc_id      = aws_vpc.main.id
+  vpc_id      = aws_vpc.main[0].id
 
   health_check {
     port = each.value.health_check_port

--- a/indexer/locals.tf
+++ b/indexer/locals.tf
@@ -7,7 +7,7 @@ locals {
   # Availability zones the indexer runs in, gated by the teardown switch. When
   # indexer_enabled=false this is an empty set, so every for_each over the AZs
   # (subnets, EIPs, private route tables) collapses to nothing.
-  azs = var.indexer_enabled ? toset(var.indexers[var.region].availability_zones) : toset([])
+  azs = local.indexer_enabled ? toset(var.indexers[var.region].availability_zones) : toset([])
 }
 
 locals {
@@ -19,7 +19,7 @@ locals {
     "vulcan",
   ]
   // Needed so that there are no circular dependencies for all resources are created per service names.
-  service_names = var.indexer_enabled ? {
+  service_names = local.indexer_enabled ? {
     for name in local.service_names_list : name => name
   } : {}
 
@@ -29,7 +29,7 @@ locals {
 }
 
 locals {
-  services = var.indexer_enabled ? {
+  services = local.indexer_enabled ? {
     "${local.service_names["ender"]}" : {
       ecs_desired_count : var.ender_ecs_desired_count,
       task_definition_memory : var.ender_task_definition_memory,
@@ -294,7 +294,7 @@ locals {
       value = "redis://${aws_elasticache_replication_group.rate_limit[0].primary_endpoint_address}:${aws_elasticache_replication_group.rate_limit[0].port}"
     }
   ]
-  lambda_services = var.indexer_enabled ? {
+  lambda_services = local.indexer_enabled ? {
     "bazooka" : {
       requires_postgres_connection : true,
       requires_redis_connection : true,

--- a/indexer/locals.tf
+++ b/indexer/locals.tf
@@ -3,6 +3,11 @@ locals {
   rds_db_name   = "dydx"
   rds_username  = "dydx"
   rds_port      = 5432
+
+  # Availability zones the indexer runs in, gated by the teardown switch. When
+  # indexer_enabled=false this is an empty set, so every for_each over the AZs
+  # (subnets, EIPs, private route tables) collapses to nothing.
+  azs = var.indexer_enabled ? toset(var.indexers[var.region].availability_zones) : toset([])
 }
 
 locals {
@@ -14,9 +19,9 @@ locals {
     "vulcan",
   ]
   // Needed so that there are no circular dependencies for all resources are created per service names.
-  service_names = {
+  service_names = var.indexer_enabled ? {
     for name in local.service_names_list : name => name
-  }
+  } : {}
 
   service_secret_ids = {
     for name in local.service_names : name => "${var.environment}-${name}-secrets"
@@ -24,7 +29,7 @@ locals {
 }
 
 locals {
-  services = {
+  services = var.indexer_enabled ? {
     "${local.service_names["ender"]}" : {
       ecs_desired_count : var.ender_ecs_desired_count,
       task_definition_memory : var.ender_task_definition_memory,
@@ -75,7 +80,7 @@ locals {
         [
           {
             name : "TENDERMINT_WS_URL",
-            value : module.full_node_ap_northeast_1.validator_rpc_url,
+            value : module.full_node_ap_northeast_1[0].validator_rpc_url,
             }, {
             name : "INDEXER_INTERNAL_IPS"
             value : join(",", [for gateway in aws_nat_gateway.main : gateway.public_ip])
@@ -128,7 +133,7 @@ locals {
           },
           {
             name : "COMLINK_URL",
-            value : aws_lb.public.dns_name,
+            value : aws_lb.public[0].dns_name,
           },
           {
             name : "INDEXER_LEVEL_GEOBLOCKING_ENABLED",
@@ -180,7 +185,7 @@ locals {
           },
           {
             name : "KMS_KEY_ARN",
-            value : aws_kms_key.rds_export.arn,
+            value : aws_kms_key.rds_export[0].arn,
           },
           {
             name : "ECS_TASK_ROLE_ARN",
@@ -188,7 +193,7 @@ locals {
           },
           {
             name : "S3_BUCKET_ARN",
-            value : aws_s3_bucket.athena_rds_snapshots.arn,
+            value : aws_s3_bucket.athena_rds_snapshots[0].arn,
           },
           {
             name  = "RDS_INSTANCE_NAME",
@@ -246,7 +251,7 @@ locals {
         ],
       ),
     },
-  }
+  } : {}
   postgres_environment_variables = [
     {
       name  = "DB_NAME",
@@ -258,7 +263,7 @@ locals {
     },
     {
       name  = "DB_HOSTNAME",
-      value = aws_db_instance.main.address,
+      value = aws_db_instance.main[0].address,
     },
     {
       name  = "DB_READONLY_HOSTNAME",
@@ -272,24 +277,24 @@ locals {
   kafka_environment_variables = [
     {
       name  = "KAFKA_BROKER_URLS",
-      value = aws_msk_cluster.main.bootstrap_brokers,
+      value = aws_msk_cluster.main[0].bootstrap_brokers,
     },
   ]
   redis_environment_variables = [
     {
       name  = "REDIS_URL",
-      value = "redis://${aws_elasticache_replication_group.main.primary_endpoint_address}:${aws_elasticache_replication_group.main.port}",
+      value = "redis://${aws_elasticache_replication_group.main[0].primary_endpoint_address}:${aws_elasticache_replication_group.main[0].port}",
     },
     {
       name  = "REDIS_READONLY_URL",
-      value = "redis://${aws_elasticache_replication_group.main.reader_endpoint_address}:${aws_elasticache_replication_group.main.port}",
+      value = "redis://${aws_elasticache_replication_group.main[0].reader_endpoint_address}:${aws_elasticache_replication_group.main[0].port}",
     },
     {
       name  = "RATE_LIMIT_REDIS_URL",
-      value = "redis://${aws_elasticache_replication_group.rate_limit.primary_endpoint_address}:${aws_elasticache_replication_group.rate_limit.port}"
+      value = "redis://${aws_elasticache_replication_group.rate_limit[0].primary_endpoint_address}:${aws_elasticache_replication_group.rate_limit[0].port}"
     }
   ]
-  lambda_services = {
+  lambda_services = var.indexer_enabled ? {
     "bazooka" : {
       requires_postgres_connection : true,
       requires_redis_connection : true,
@@ -306,7 +311,7 @@ locals {
       requires_upgrade_indexer_iam_policies : true,
       environment_variables : {},
     }
-  }
+  } : {}
 }
 
 # Taken from https://github.com/dydxprotocol/indexer/blob/master/packages/base/src/logger.ts#L22
@@ -331,7 +336,7 @@ locals {
     },
     {
       name  = "KMS Policy",
-      value = aws_iam_policy.kms_policy.arn,
+      value = aws_iam_policy.kms_policy[0].arn,
     }
   ]
 }

--- a/indexer/msk.tf
+++ b/indexer/msk.tf
@@ -1,5 +1,5 @@
 resource "aws_msk_configuration" "main" {
-  count          = var.indexer_enabled ? 1 : 0
+  count          = local.indexer_enabled ? 1 : 0
   kafka_versions = [local.kafka_version]
   // create_before_destroy=true forces a new name because the old resource not delete first. For now we only trigger
   // replacement for new kafka versions, so use the kafka version in the name
@@ -31,7 +31,7 @@ resource "aws_msk_configuration" "main" {
 }
 
 resource "aws_msk_cluster" "main" {
-  count                  = var.indexer_enabled ? 1 : 0
+  count                  = local.indexer_enabled ? 1 : 0
   cluster_name           = "${var.environment}-${var.indexers[var.region].name}-msk-cluster"
   kafka_version          = local.kafka_version
   number_of_broker_nodes = 3

--- a/indexer/msk.tf
+++ b/indexer/msk.tf
@@ -1,4 +1,5 @@
 resource "aws_msk_configuration" "main" {
+  count          = var.indexer_enabled ? 1 : 0
   kafka_versions = [local.kafka_version]
   // create_before_destroy=true forces a new name because the old resource not delete first. For now we only trigger
   // replacement for new kafka versions, so use the kafka version in the name
@@ -30,6 +31,7 @@ resource "aws_msk_configuration" "main" {
 }
 
 resource "aws_msk_cluster" "main" {
+  count                  = var.indexer_enabled ? 1 : 0
   cluster_name           = "${var.environment}-${var.indexers[var.region].name}-msk-cluster"
   kafka_version          = local.kafka_version
   number_of_broker_nodes = 3
@@ -53,7 +55,7 @@ resource "aws_msk_cluster" "main" {
     client_subnets = [
       for subnet in aws_subnet.private_subnets : subnet.id
     ]
-    security_groups = [aws_security_group.msk.id]
+    security_groups = [aws_security_group.msk[0].id]
   }
 
   open_monitoring {
@@ -75,7 +77,7 @@ resource "aws_msk_cluster" "main" {
   }
 
   configuration_info {
-    arn      = aws_msk_configuration.main.arn
-    revision = aws_msk_configuration.main.latest_revision
+    arn      = aws_msk_configuration.main[0].arn
+    revision = aws_msk_configuration.main[0].latest_revision
   }
 }

--- a/indexer/network_acl_private.tf
+++ b/indexer/network_acl_private.tf
@@ -2,7 +2,7 @@
 # Network ACL private subnets
 # -----------------------------------------------------------------------------
 resource "aws_network_acl" "private" {
-  count      = var.indexer_enabled ? 1 : 0
+  count      = local.indexer_enabled ? 1 : 0
   vpc_id     = aws_vpc.main[0].id
   subnet_ids = [for subnet in aws_subnet.private_subnets : subnet.id]
 
@@ -20,7 +20,7 @@ resource "aws_network_acl" "private" {
 # Allow all outgoing messages from public subnets
 # TODO(DEC-900): Investigate if further restricting ACL rules
 resource "aws_network_acl_rule" "private_egress_allow_all" {
-  count          = var.indexer_enabled ? 1 : 0
+  count          = local.indexer_enabled ? 1 : 0
   network_acl_id = aws_network_acl.private[0].id
   rule_number    = 50
   egress         = true
@@ -35,7 +35,7 @@ resource "aws_network_acl_rule" "private_egress_allow_all" {
 # Allow all incoming messages from within VPC
 # TODO(DEC-900): Investigate if further restricting ACL rules
 resource "aws_network_acl_rule" "private_ingress_allow_all_from_vpc" {
-  count          = var.indexer_enabled ? 1 : 0
+  count          = local.indexer_enabled ? 1 : 0
   network_acl_id = aws_network_acl.private[0].id
   rule_number    = 50
   egress         = false
@@ -47,7 +47,7 @@ resource "aws_network_acl_rule" "private_ingress_allow_all_from_vpc" {
 # Allow all incoming TCP messages from port 79 to 65535
 # TODO(DEC-900): Investigate if further restricting ACL rules
 resource "aws_network_acl_rule" "private_ingress_allow_all_tcp" {
-  count          = var.indexer_enabled ? 1 : 0
+  count          = local.indexer_enabled ? 1 : 0
   network_acl_id = aws_network_acl.private[0].id
   rule_number    = 100
   egress         = false
@@ -61,7 +61,7 @@ resource "aws_network_acl_rule" "private_ingress_allow_all_tcp" {
 # Allow all incoming UDP messages from port 79 to 65535
 # TODO(DEC-900): Investigate if further restricting ACL rules
 resource "aws_network_acl_rule" "private_ingress_allow_all_udp" {
-  count          = var.indexer_enabled ? 1 : 0
+  count          = local.indexer_enabled ? 1 : 0
   network_acl_id = aws_network_acl.private[0].id
   rule_number    = 110
   egress         = false
@@ -75,7 +75,7 @@ resource "aws_network_acl_rule" "private_ingress_allow_all_udp" {
 # Allow all incoming SSH from port 22
 # TODO(DEC-900): Investigate if further restricting ACL rules
 resource "aws_network_acl_rule" "private_ingress_allow_ssh" {
-  count          = var.indexer_enabled ? 1 : 0
+  count          = local.indexer_enabled ? 1 : 0
   network_acl_id = aws_network_acl.private[0].id
   rule_number    = 120
   egress         = false

--- a/indexer/network_acl_private.tf
+++ b/indexer/network_acl_private.tf
@@ -2,7 +2,8 @@
 # Network ACL private subnets
 # -----------------------------------------------------------------------------
 resource "aws_network_acl" "private" {
-  vpc_id     = aws_vpc.main.id
+  count      = var.indexer_enabled ? 1 : 0
+  vpc_id     = aws_vpc.main[0].id
   subnet_ids = [for subnet in aws_subnet.private_subnets : subnet.id]
 
   tags = {
@@ -19,7 +20,8 @@ resource "aws_network_acl" "private" {
 # Allow all outgoing messages from public subnets
 # TODO(DEC-900): Investigate if further restricting ACL rules
 resource "aws_network_acl_rule" "private_egress_allow_all" {
-  network_acl_id = aws_network_acl.private.id
+  count          = var.indexer_enabled ? 1 : 0
+  network_acl_id = aws_network_acl.private[0].id
   rule_number    = 50
   egress         = true
   protocol       = "-1"
@@ -33,18 +35,20 @@ resource "aws_network_acl_rule" "private_egress_allow_all" {
 # Allow all incoming messages from within VPC
 # TODO(DEC-900): Investigate if further restricting ACL rules
 resource "aws_network_acl_rule" "private_ingress_allow_all_from_vpc" {
-  network_acl_id = aws_network_acl.private.id
+  count          = var.indexer_enabled ? 1 : 0
+  network_acl_id = aws_network_acl.private[0].id
   rule_number    = 50
   egress         = false
   protocol       = "-1"
   rule_action    = "allow"
-  cidr_block     = aws_vpc.main.cidr_block
+  cidr_block     = aws_vpc.main[0].cidr_block
 }
 
 # Allow all incoming TCP messages from port 79 to 65535
 # TODO(DEC-900): Investigate if further restricting ACL rules
 resource "aws_network_acl_rule" "private_ingress_allow_all_tcp" {
-  network_acl_id = aws_network_acl.private.id
+  count          = var.indexer_enabled ? 1 : 0
+  network_acl_id = aws_network_acl.private[0].id
   rule_number    = 100
   egress         = false
   protocol       = "tcp"
@@ -57,7 +61,8 @@ resource "aws_network_acl_rule" "private_ingress_allow_all_tcp" {
 # Allow all incoming UDP messages from port 79 to 65535
 # TODO(DEC-900): Investigate if further restricting ACL rules
 resource "aws_network_acl_rule" "private_ingress_allow_all_udp" {
-  network_acl_id = aws_network_acl.private.id
+  count          = var.indexer_enabled ? 1 : 0
+  network_acl_id = aws_network_acl.private[0].id
   rule_number    = 110
   egress         = false
   protocol       = "udp"
@@ -70,7 +75,8 @@ resource "aws_network_acl_rule" "private_ingress_allow_all_udp" {
 # Allow all incoming SSH from port 22
 # TODO(DEC-900): Investigate if further restricting ACL rules
 resource "aws_network_acl_rule" "private_ingress_allow_ssh" {
-  network_acl_id = aws_network_acl.private.id
+  count          = var.indexer_enabled ? 1 : 0
+  network_acl_id = aws_network_acl.private[0].id
   rule_number    = 120
   egress         = false
   protocol       = "tcp"

--- a/indexer/network_acl_public.tf
+++ b/indexer/network_acl_public.tf
@@ -2,7 +2,8 @@
 # Network ACL and ACL rules for public subnets
 # -----------------------------------------------------------------------------
 resource "aws_network_acl" "public" {
-  vpc_id     = aws_vpc.main.id
+  count      = var.indexer_enabled ? 1 : 0
+  vpc_id     = aws_vpc.main[0].id
   subnet_ids = [for subnet in aws_subnet.public_subnets : subnet.id]
 
   tags = {
@@ -19,7 +20,8 @@ resource "aws_network_acl" "public" {
 # Allow all outgoing messages from public subnets
 # TODO(DEC-900): Investigate if further restricting ACL rules
 resource "aws_network_acl_rule" "public_egress_allow_all" {
-  network_acl_id = aws_network_acl.public.id
+  count          = var.indexer_enabled ? 1 : 0
+  network_acl_id = aws_network_acl.public[0].id
   rule_number    = 50
   egress         = true
   protocol       = "-1"
@@ -33,18 +35,20 @@ resource "aws_network_acl_rule" "public_egress_allow_all" {
 # Allow all incoming messages from within VPC
 # TODO(DEC-900): Investigate if further restricting ACL rules
 resource "aws_network_acl_rule" "public_ingress_allow_all_from_vpc" {
-  network_acl_id = aws_network_acl.public.id
+  count          = var.indexer_enabled ? 1 : 0
+  network_acl_id = aws_network_acl.public[0].id
   rule_number    = 50
   egress         = false
   protocol       = "-1"
   rule_action    = "allow"
-  cidr_block     = aws_vpc.main.cidr_block
+  cidr_block     = aws_vpc.main[0].cidr_block
 }
 
 # Allow all incoming TCP requests
 # TODO(DEC-900): Investigate if further restricting ACL rules
 resource "aws_network_acl_rule" "public_ingress_allow_all_tcp" {
-  network_acl_id = aws_network_acl.public.id
+  count          = var.indexer_enabled ? 1 : 0
+  network_acl_id = aws_network_acl.public[0].id
   rule_number    = 100
   egress         = false
   protocol       = "tcp"
@@ -57,7 +61,8 @@ resource "aws_network_acl_rule" "public_ingress_allow_all_tcp" {
 # Allow all incoming UDP requests
 # TODO(DEC-900): Investigate if further restricting ACL rules
 resource "aws_network_acl_rule" "public_ingress_allow_all_udp" {
-  network_acl_id = aws_network_acl.public.id
+  count          = var.indexer_enabled ? 1 : 0
+  network_acl_id = aws_network_acl.public[0].id
   rule_number    = 110
   egress         = false
   protocol       = "udp"
@@ -70,7 +75,8 @@ resource "aws_network_acl_rule" "public_ingress_allow_all_udp" {
 # Allow all incoming SSH from port 22
 # TODO(DEC-900): Investigate if further restricting ACL rules
 resource "aws_network_acl_rule" "public_ingress_allow_ssh" {
-  network_acl_id = aws_network_acl.public.id
+  count          = var.indexer_enabled ? 1 : 0
+  network_acl_id = aws_network_acl.public[0].id
   rule_number    = 120
   egress         = false
   protocol       = "tcp"

--- a/indexer/network_acl_public.tf
+++ b/indexer/network_acl_public.tf
@@ -2,7 +2,7 @@
 # Network ACL and ACL rules for public subnets
 # -----------------------------------------------------------------------------
 resource "aws_network_acl" "public" {
-  count      = var.indexer_enabled ? 1 : 0
+  count      = local.indexer_enabled ? 1 : 0
   vpc_id     = aws_vpc.main[0].id
   subnet_ids = [for subnet in aws_subnet.public_subnets : subnet.id]
 
@@ -20,7 +20,7 @@ resource "aws_network_acl" "public" {
 # Allow all outgoing messages from public subnets
 # TODO(DEC-900): Investigate if further restricting ACL rules
 resource "aws_network_acl_rule" "public_egress_allow_all" {
-  count          = var.indexer_enabled ? 1 : 0
+  count          = local.indexer_enabled ? 1 : 0
   network_acl_id = aws_network_acl.public[0].id
   rule_number    = 50
   egress         = true
@@ -35,7 +35,7 @@ resource "aws_network_acl_rule" "public_egress_allow_all" {
 # Allow all incoming messages from within VPC
 # TODO(DEC-900): Investigate if further restricting ACL rules
 resource "aws_network_acl_rule" "public_ingress_allow_all_from_vpc" {
-  count          = var.indexer_enabled ? 1 : 0
+  count          = local.indexer_enabled ? 1 : 0
   network_acl_id = aws_network_acl.public[0].id
   rule_number    = 50
   egress         = false
@@ -47,7 +47,7 @@ resource "aws_network_acl_rule" "public_ingress_allow_all_from_vpc" {
 # Allow all incoming TCP requests
 # TODO(DEC-900): Investigate if further restricting ACL rules
 resource "aws_network_acl_rule" "public_ingress_allow_all_tcp" {
-  count          = var.indexer_enabled ? 1 : 0
+  count          = local.indexer_enabled ? 1 : 0
   network_acl_id = aws_network_acl.public[0].id
   rule_number    = 100
   egress         = false
@@ -61,7 +61,7 @@ resource "aws_network_acl_rule" "public_ingress_allow_all_tcp" {
 # Allow all incoming UDP requests
 # TODO(DEC-900): Investigate if further restricting ACL rules
 resource "aws_network_acl_rule" "public_ingress_allow_all_udp" {
-  count          = var.indexer_enabled ? 1 : 0
+  count          = local.indexer_enabled ? 1 : 0
   network_acl_id = aws_network_acl.public[0].id
   rule_number    = 110
   egress         = false
@@ -75,7 +75,7 @@ resource "aws_network_acl_rule" "public_ingress_allow_all_udp" {
 # Allow all incoming SSH from port 22
 # TODO(DEC-900): Investigate if further restricting ACL rules
 resource "aws_network_acl_rule" "public_ingress_allow_ssh" {
-  count          = var.indexer_enabled ? 1 : 0
+  count          = local.indexer_enabled ? 1 : 0
   network_acl_id = aws_network_acl.public[0].id
   rule_number    = 120
   egress         = false

--- a/indexer/rds.tf
+++ b/indexer/rds.tf
@@ -5,7 +5,7 @@ locals {
 
 # Subnets to associate with the RDS instance.
 resource "aws_db_subnet_group" "main" {
-  count = var.indexer_enabled ? 1 : 0
+  count = local.indexer_enabled ? 1 : 0
   name  = "${var.environment}-${var.indexers[var.region].name}-db-subnet"
   # Use the first private subnet as the RDS instance will not be publicly accessible,
   # and so the db is always located in the same subnet.
@@ -20,7 +20,7 @@ resource "aws_db_subnet_group" "main" {
 # DB parameter group for the RDS instance. Sets various Postgres specific parameters for the
 # instance.
 resource "aws_db_parameter_group" "main" {
-  count  = var.indexer_enabled ? 1 : 0
+  count  = local.indexer_enabled ? 1 : 0
   name   = var.rds_parameter_group_override_name
   family = var.rds_parameter_group_family
 
@@ -52,14 +52,14 @@ data "aws_secretsmanager_secret_version" "ender_secrets" {
 
 # RDS instance.
 resource "aws_db_instance" "main" {
-  count                                 = var.indexer_enabled ? 1 : 0
+  count                                 = local.indexer_enabled ? 1 : 0
   allocated_storage                     = var.rds_db_allocated_storage_gb
   auto_minor_version_upgrade            = false
   backup_retention_period               = 3
   db_name                               = local.rds_db_name
   db_subnet_group_name                  = aws_db_subnet_group.main[0].name
   delete_automated_backups              = false
-  deletion_protection                   = var.indexer_teardown_disarm ? false : true
+  deletion_protection                   = local.indexer_teardown_disarm ? false : true
   enabled_cloudwatch_logs_exports       = ["iam-db-auth-error", "postgresql", "upgrade"]
   copy_tags_to_snapshot                 = true
   engine                                = local.db_engine
@@ -88,10 +88,10 @@ resource "aws_db_instance" "main" {
 
 # Read replica
 resource "aws_db_instance" "read_replica" {
-  count                                 = var.indexer_enabled && var.create_read_replica ? 1 : 0
+  count                                 = local.indexer_enabled && var.create_read_replica ? 1 : 0
   allocated_storage                     = var.rds_db_allocated_storage_gb
   auto_minor_version_upgrade            = true
-  deletion_protection                   = var.indexer_teardown_disarm ? false : true
+  deletion_protection                   = local.indexer_teardown_disarm ? false : true
   identifier                            = "${local.aws_db_instance_main_name}-read-replica"
   instance_class                        = var.rds_db_replica_instance_class
   monitoring_interval                   = coalesce(var.rds_read_replica_monitoring_interval, var.rds_monitoring_interval)
@@ -118,8 +118,8 @@ resource "aws_db_instance" "read_replica" {
 resource "aws_db_instance" "read_replica_2" {
   allocated_storage                     = var.rds_db_allocated_storage_gb
   auto_minor_version_upgrade            = false
-  count                                 = var.indexer_enabled && var.create_read_replica_2 ? 1 : 0
-  deletion_protection                   = var.indexer_teardown_disarm ? false : true
+  count                                 = local.indexer_enabled && var.create_read_replica_2 ? 1 : 0
+  deletion_protection                   = local.indexer_teardown_disarm ? false : true
   identifier                            = "${local.aws_db_instance_main_name}-read-replica-2"
   instance_class                        = var.rds_db_replica_instance_class
   monitoring_interval                   = coalesce(var.rds_read_replica_monitoring_interval, var.rds_monitoring_interval)
@@ -144,8 +144,8 @@ resource "aws_db_instance" "read_replica_2" {
 resource "aws_db_instance" "read_replica_analytics" {
   allocated_storage                     = var.rds_db_allocated_storage_gb
   auto_minor_version_upgrade            = false
-  count                                 = var.indexer_enabled && var.create_read_replica_analytics ? 1 : 0
-  deletion_protection                   = var.indexer_teardown_disarm ? false : true
+  count                                 = local.indexer_enabled && var.create_read_replica_analytics ? 1 : 0
+  deletion_protection                   = local.indexer_teardown_disarm ? false : true
   identifier                            = "${local.aws_db_instance_main_name}-read-replica-analytics"
   instance_class                        = var.rds_db_replica_instance_class
   monitoring_interval                   = coalesce(var.rds_read_replica_monitoring_interval, var.rds_monitoring_interval)

--- a/indexer/rds.tf
+++ b/indexer/rds.tf
@@ -5,7 +5,8 @@ locals {
 
 # Subnets to associate with the RDS instance.
 resource "aws_db_subnet_group" "main" {
-  name = "${var.environment}-${var.indexers[var.region].name}-db-subnet"
+  count = var.indexer_enabled ? 1 : 0
+  name  = "${var.environment}-${var.indexers[var.region].name}-db-subnet"
   # Use the first private subnet as the RDS instance will not be publicly accessible,
   # and so the db is always located in the same subnet.
   subnet_ids = [for subnet_name in var.indexers[var.region].rds_availability_regions : aws_subnet.private_subnets[subnet_name].id]
@@ -19,6 +20,7 @@ resource "aws_db_subnet_group" "main" {
 # DB parameter group for the RDS instance. Sets various Postgres specific parameters for the
 # instance.
 resource "aws_db_parameter_group" "main" {
+  count  = var.indexer_enabled ? 1 : 0
   name   = var.rds_parameter_group_override_name
   family = var.rds_parameter_group_family
 
@@ -50,13 +52,14 @@ data "aws_secretsmanager_secret_version" "ender_secrets" {
 
 # RDS instance.
 resource "aws_db_instance" "main" {
+  count                                 = var.indexer_enabled ? 1 : 0
   allocated_storage                     = var.rds_db_allocated_storage_gb
   auto_minor_version_upgrade            = false
   backup_retention_period               = 3
   db_name                               = local.rds_db_name
-  db_subnet_group_name                  = aws_db_subnet_group.main.name
+  db_subnet_group_name                  = aws_db_subnet_group.main[0].name
   delete_automated_backups              = false
-  deletion_protection                   = true
+  deletion_protection                   = var.indexer_teardown_disarm ? false : true
   enabled_cloudwatch_logs_exports       = ["iam-db-auth-error", "postgresql", "upgrade"]
   copy_tags_to_snapshot                 = true
   engine                                = local.db_engine
@@ -72,7 +75,7 @@ resource "aws_db_instance" "main" {
   publicly_accessible                   = false
   skip_final_snapshot                   = true
   username                              = local.rds_username
-  vpc_security_group_ids                = [aws_security_group.rds.id]
+  vpc_security_group_ids                = [aws_security_group.rds[0].id]
 
   # Set to true if any planned changes need to be applied before the next maintenance window.
   apply_immediately = false
@@ -85,10 +88,10 @@ resource "aws_db_instance" "main" {
 
 # Read replica
 resource "aws_db_instance" "read_replica" {
-  count                                 = var.create_read_replica ? 1 : 0
+  count                                 = var.indexer_enabled && var.create_read_replica ? 1 : 0
   allocated_storage                     = var.rds_db_allocated_storage_gb
   auto_minor_version_upgrade            = true
-  deletion_protection                   = true
+  deletion_protection                   = var.indexer_teardown_disarm ? false : true
   identifier                            = "${local.aws_db_instance_main_name}-read-replica"
   instance_class                        = var.rds_db_replica_instance_class
   monitoring_interval                   = coalesce(var.rds_read_replica_monitoring_interval, var.rds_monitoring_interval)
@@ -98,9 +101,9 @@ resource "aws_db_instance" "read_replica" {
   performance_insights_enabled          = true
   performance_insights_retention_period = 465
   publicly_accessible                   = false
-  replicate_source_db                   = aws_db_instance.main.identifier
+  replicate_source_db                   = aws_db_instance.main[0].identifier
   skip_final_snapshot                   = true
-  vpc_security_group_ids                = [aws_security_group.rds.id]
+  vpc_security_group_ids                = [aws_security_group.rds[0].id]
 
   # Set to true if any planned changes need to be applied before the next maintenance window.
   apply_immediately = false
@@ -115,8 +118,8 @@ resource "aws_db_instance" "read_replica" {
 resource "aws_db_instance" "read_replica_2" {
   allocated_storage                     = var.rds_db_allocated_storage_gb
   auto_minor_version_upgrade            = false
-  count                                 = var.create_read_replica_2 ? 1 : 0
-  deletion_protection                   = true
+  count                                 = var.indexer_enabled && var.create_read_replica_2 ? 1 : 0
+  deletion_protection                   = var.indexer_teardown_disarm ? false : true
   identifier                            = "${local.aws_db_instance_main_name}-read-replica-2"
   instance_class                        = var.rds_db_replica_instance_class
   monitoring_interval                   = coalesce(var.rds_read_replica_monitoring_interval, var.rds_monitoring_interval)
@@ -125,9 +128,9 @@ resource "aws_db_instance" "read_replica_2" {
   performance_insights_enabled          = true
   performance_insights_retention_period = 31
   publicly_accessible                   = false
-  replicate_source_db                   = aws_db_instance.main.identifier
+  replicate_source_db                   = aws_db_instance.main[0].identifier
   skip_final_snapshot                   = true
-  vpc_security_group_ids                = [aws_security_group.rds.id]
+  vpc_security_group_ids                = [aws_security_group.rds[0].id]
 
   # Set to true if any planned changes need to be applied before the next maintenance window.
   apply_immediately = false
@@ -141,8 +144,8 @@ resource "aws_db_instance" "read_replica_2" {
 resource "aws_db_instance" "read_replica_analytics" {
   allocated_storage                     = var.rds_db_allocated_storage_gb
   auto_minor_version_upgrade            = false
-  count                                 = var.create_read_replica_analytics ? 1 : 0
-  deletion_protection                   = true
+  count                                 = var.indexer_enabled && var.create_read_replica_analytics ? 1 : 0
+  deletion_protection                   = var.indexer_teardown_disarm ? false : true
   identifier                            = "${local.aws_db_instance_main_name}-read-replica-analytics"
   instance_class                        = var.rds_db_replica_instance_class
   monitoring_interval                   = coalesce(var.rds_read_replica_monitoring_interval, var.rds_monitoring_interval)
@@ -151,9 +154,9 @@ resource "aws_db_instance" "read_replica_analytics" {
   performance_insights_enabled          = true
   performance_insights_retention_period = 31
   publicly_accessible                   = false
-  replicate_source_db                   = aws_db_instance.main.identifier
+  replicate_source_db                   = aws_db_instance.main[0].identifier
   skip_final_snapshot                   = true
-  vpc_security_group_ids                = [aws_security_group.rds.id]
+  vpc_security_group_ids                = [aws_security_group.rds[0].id]
 
   # Set to true if any planned changes need to be applied before the next maintenance window.
   apply_immediately = false

--- a/indexer/route53.tf
+++ b/indexer/route53.tf
@@ -1,14 +1,15 @@
 resource "aws_route53_zone" "main" {
-  name = "dydx-indexer.private"
+  count = var.indexer_enabled ? 1 : 0
+  name  = "dydx-indexer.private"
 
   vpc {
-    vpc_id = aws_vpc.main.id
+    vpc_id = aws_vpc.main[0].id
   }
 }
 
 resource "aws_route53_record" "read_replica_1" {
-  count   = var.create_read_replica ? 1 : 0
-  zone_id = aws_route53_zone.main.zone_id
+  count   = var.indexer_enabled && var.create_read_replica ? 1 : 0
+  zone_id = aws_route53_zone.main[0].zone_id
   name    = "postgres-main-rr.dydx-indexer.private"
   type    = "CNAME"
   ttl     = "30"
@@ -20,8 +21,8 @@ resource "aws_route53_record" "read_replica_1" {
 }
 
 resource "aws_route53_record" "read_replica_2" {
-  count   = var.create_read_replica_2 ? 1 : 0
-  zone_id = aws_route53_zone.main.zone_id
+  count   = var.indexer_enabled && var.create_read_replica_2 ? 1 : 0
+  zone_id = aws_route53_zone.main[0].zone_id
   name    = "postgres-main-rr.dydx-indexer.private"
   type    = "CNAME"
   ttl     = "30"

--- a/indexer/route53.tf
+++ b/indexer/route53.tf
@@ -1,5 +1,5 @@
 resource "aws_route53_zone" "main" {
-  count = var.indexer_enabled ? 1 : 0
+  count = local.indexer_enabled ? 1 : 0
   name  = "dydx-indexer.private"
 
   vpc {
@@ -8,7 +8,7 @@ resource "aws_route53_zone" "main" {
 }
 
 resource "aws_route53_record" "read_replica_1" {
-  count   = var.indexer_enabled && var.create_read_replica ? 1 : 0
+  count   = local.indexer_enabled && var.create_read_replica ? 1 : 0
   zone_id = aws_route53_zone.main[0].zone_id
   name    = "postgres-main-rr.dydx-indexer.private"
   type    = "CNAME"
@@ -21,7 +21,7 @@ resource "aws_route53_record" "read_replica_1" {
 }
 
 resource "aws_route53_record" "read_replica_2" {
-  count   = var.indexer_enabled && var.create_read_replica_2 ? 1 : 0
+  count   = local.indexer_enabled && var.create_read_replica_2 ? 1 : 0
   zone_id = aws_route53_zone.main[0].zone_id
   name    = "postgres-main-rr.dydx-indexer.private"
   type    = "CNAME"

--- a/indexer/route_table.tf
+++ b/indexer/route_table.tf
@@ -1,6 +1,7 @@
 # Public facing Route Table.
 resource "aws_route_table" "public" {
-  vpc_id = aws_vpc.main.id
+  count  = var.indexer_enabled ? 1 : 0
+  vpc_id = aws_vpc.main[0].id
 
   tags = {
     Name        = "${var.environment}-${var.indexers[var.region].name}-routing-table-public"
@@ -9,9 +10,10 @@ resource "aws_route_table" "public" {
 }
 
 resource "aws_route" "public" {
-  route_table_id         = aws_route_table.public.id
+  count                  = var.indexer_enabled ? 1 : 0
+  route_table_id         = aws_route_table.public[0].id
   destination_cidr_block = "0.0.0.0/0"
-  gateway_id             = aws_internet_gateway.main.id
+  gateway_id             = aws_internet_gateway.main[0].id
 }
 
 # Public facing Route Table association with subnet.
@@ -21,13 +23,13 @@ resource "aws_route_table_association" "public" {
   for_each = aws_subnet.public_subnets
 
   subnet_id      = each.value.id
-  route_table_id = aws_route_table.public.id
+  route_table_id = aws_route_table.public[0].id
 }
 
 # Private facing Route Tables.
 resource "aws_route_table" "private" {
-  for_each = toset(var.indexers[var.region].availability_zones)
-  vpc_id   = aws_vpc.main.id
+  for_each = local.azs
+  vpc_id   = aws_vpc.main[0].id
 
   tags = {
     Name        = "${var.environment}-${var.indexers[var.region].name}-${each.key}-routing-table-private"
@@ -58,9 +60,10 @@ resource "aws_route_table_association" "private" {
 # NOTE: This is not an individual AWS resource, but rather an attachment to the route table, and so
 # no tags are added.
 resource "aws_route" "full_node_route_to_indexer" {
-  route_table_id            = module.full_node_ap_northeast_1.route_table_id
+  count                     = var.indexer_enabled ? 1 : 0
+  route_table_id            = module.full_node_ap_northeast_1[0].route_table_id
   destination_cidr_block    = var.indexers[var.region].vpc_cidr_block
-  vpc_peering_connection_id = aws_vpc_peering_connection.full_node_peer.id
+  vpc_peering_connection_id = aws_vpc_peering_connection.full_node_peer[0].id
 }
 
 # Route from the backup full node's VPC to the Indexer's VPC. Needed so that the backup full node can connect to
@@ -68,7 +71,7 @@ resource "aws_route" "full_node_route_to_indexer" {
 # NOTE: This is not an individual AWS resource, but rather an attachment to the route table, and so
 # no tags are added.
 resource "aws_route" "backup_full_node_route_to_indexer" {
-  count                     = var.create_backup_full_node ? 1 : 0
+  count                     = var.indexer_enabled && var.create_backup_full_node ? 1 : 0
   route_table_id            = module.backup_full_node_ap_northeast_1[0].route_table_id
   destination_cidr_block    = var.indexers[var.region].vpc_cidr_block
   vpc_peering_connection_id = aws_vpc_peering_connection.backup_full_node_peer[0].id
@@ -85,11 +88,11 @@ resource "aws_route" "indexer_route_to_full_node" {
 
   route_table_id            = each.value.id
   destination_cidr_block    = var.full_node_cidr_vpc
-  vpc_peering_connection_id = aws_vpc_peering_connection.full_node_peer.id
+  vpc_peering_connection_id = aws_vpc_peering_connection.full_node_peer[0].id
 }
 
 resource "aws_route" "indexer_route_to_backup_full_node" {
-  for_each = var.create_backup_full_node ? aws_route_table.private : {}
+  for_each = var.indexer_enabled && var.create_backup_full_node ? aws_route_table.private : {}
 
   route_table_id            = each.value.id
   destination_cidr_block    = var.backup_full_node_cidr_vpc

--- a/indexer/route_table.tf
+++ b/indexer/route_table.tf
@@ -1,6 +1,6 @@
 # Public facing Route Table.
 resource "aws_route_table" "public" {
-  count  = var.indexer_enabled ? 1 : 0
+  count  = local.indexer_enabled ? 1 : 0
   vpc_id = aws_vpc.main[0].id
 
   tags = {
@@ -10,7 +10,7 @@ resource "aws_route_table" "public" {
 }
 
 resource "aws_route" "public" {
-  count                  = var.indexer_enabled ? 1 : 0
+  count                  = local.indexer_enabled ? 1 : 0
   route_table_id         = aws_route_table.public[0].id
   destination_cidr_block = "0.0.0.0/0"
   gateway_id             = aws_internet_gateway.main[0].id
@@ -60,7 +60,7 @@ resource "aws_route_table_association" "private" {
 # NOTE: This is not an individual AWS resource, but rather an attachment to the route table, and so
 # no tags are added.
 resource "aws_route" "full_node_route_to_indexer" {
-  count                     = var.indexer_enabled ? 1 : 0
+  count                     = local.indexer_enabled ? 1 : 0
   route_table_id            = module.full_node_ap_northeast_1[0].route_table_id
   destination_cidr_block    = var.indexers[var.region].vpc_cidr_block
   vpc_peering_connection_id = aws_vpc_peering_connection.full_node_peer[0].id
@@ -71,7 +71,7 @@ resource "aws_route" "full_node_route_to_indexer" {
 # NOTE: This is not an individual AWS resource, but rather an attachment to the route table, and so
 # no tags are added.
 resource "aws_route" "backup_full_node_route_to_indexer" {
-  count                     = var.indexer_enabled && var.create_backup_full_node ? 1 : 0
+  count                     = local.indexer_enabled && var.create_backup_full_node ? 1 : 0
   route_table_id            = module.backup_full_node_ap_northeast_1[0].route_table_id
   destination_cidr_block    = var.indexers[var.region].vpc_cidr_block
   vpc_peering_connection_id = aws_vpc_peering_connection.backup_full_node_peer[0].id
@@ -92,7 +92,7 @@ resource "aws_route" "indexer_route_to_full_node" {
 }
 
 resource "aws_route" "indexer_route_to_backup_full_node" {
-  for_each = var.indexer_enabled && var.create_backup_full_node ? aws_route_table.private : {}
+  for_each = local.indexer_enabled && var.create_backup_full_node ? aws_route_table.private : {}
 
   route_table_id            = each.value.id
   destination_cidr_block    = var.backup_full_node_cidr_vpc

--- a/indexer/s3_bucket.tf
+++ b/indexer/s3_bucket.tf
@@ -1,5 +1,6 @@
 # AWS S3 bucket to store all load balancer logs
 resource "aws_s3_bucket" "load_balancer" {
+  count         = var.indexer_enabled ? 1 : 0
   bucket        = "${local.account_id}-${var.environment}-${var.indexers[var.region].name}-lb-public-logs"
   force_destroy = true
 
@@ -10,8 +11,8 @@ resource "aws_s3_bucket" "load_balancer" {
 }
 
 resource "aws_s3_bucket_lifecycle_configuration" "load_balancer" {
-  count  = var.enable_s3_load_balancer_logs_lifecycle ? 1 : 0
-  bucket = aws_s3_bucket.load_balancer.id
+  count  = var.indexer_enabled && var.enable_s3_load_balancer_logs_lifecycle ? 1 : 0
+  bucket = aws_s3_bucket.load_balancer[0].id
 
   rule {
     id     = "expire-old-logs"
@@ -30,9 +31,11 @@ resource "aws_s3_bucket_lifecycle_configuration" "load_balancer" {
 # TODO: refactor snapshotting full node into a separate module
 # AWS S3 bucket to store all Indexer full node snapshots
 resource "aws_s3_bucket" "indexer_full_node_snapshots" {
+  count = var.indexer_enabled ? 1 : 0
   # Use account id for mainnet to avoid name collisions
   # TODO(IND-457): Migrate files in other envs and update bucket name
-  bucket = var.environment == "mainnet" ? "${local.account_id}-${var.s3_snapshot_bucket}" : var.s3_snapshot_bucket
+  bucket        = var.environment == "mainnet" ? "${local.account_id}-${var.s3_snapshot_bucket}" : var.s3_snapshot_bucket
+  force_destroy = var.indexer_teardown_disarm
 
   tags = {
     Name        = "${local.account_id}-${var.environment}-full-node-snapshots"
@@ -41,8 +44,8 @@ resource "aws_s3_bucket" "indexer_full_node_snapshots" {
 }
 
 resource "aws_s3_bucket_lifecycle_configuration" "indexer_full_node_snapshots" {
-  count  = var.enable_s3_snapshot_lifecycle ? 1 : 0
-  bucket = aws_s3_bucket.indexer_full_node_snapshots.id
+  count  = var.indexer_enabled && var.enable_s3_snapshot_lifecycle ? 1 : 0
+  bucket = aws_s3_bucket.indexer_full_node_snapshots[0].id
 
   rule {
     id     = "expire-old-snapshots"
@@ -61,19 +64,22 @@ resource "aws_s3_bucket_lifecycle_configuration" "indexer_full_node_snapshots" {
 
 # Enable S3 bucket metrics to be sent to Datadog for monitoring
 resource "aws_s3_bucket_metric" "indexer_full_node_snapshots" {
-  bucket = aws_s3_bucket.indexer_full_node_snapshots.id
+  count  = var.indexer_enabled ? 1 : 0
+  bucket = aws_s3_bucket.indexer_full_node_snapshots[0].id
   name   = "EntireBucket"
 }
 
 # Attach policy to s3 bucket to allow load balancer to write logs to the S3 bucket
 # NOTE: This resource cannot be tagged.
 resource "aws_s3_bucket_policy" "lb_s3_bucket_policy" {
-  bucket = aws_s3_bucket.load_balancer.id
-  policy = data.aws_iam_policy_document.lb_s3_bucket_policy.json
+  count  = var.indexer_enabled ? 1 : 0
+  bucket = aws_s3_bucket.load_balancer[0].id
+  policy = data.aws_iam_policy_document.lb_s3_bucket_policy[0].json
 }
 
 # Policy to allow load balancer to write logs into the s3 bucket
 data "aws_iam_policy_document" "lb_s3_bucket_policy" {
+  count = var.indexer_enabled ? 1 : 0
   statement {
     principals {
       type        = "AWS"
@@ -85,14 +91,15 @@ data "aws_iam_policy_document" "lb_s3_bucket_policy" {
     ]
 
     resources = [
-      aws_s3_bucket.load_balancer.arn,
-      "${aws_s3_bucket.load_balancer.arn}/*"
+      aws_s3_bucket.load_balancer[0].arn,
+      "${aws_s3_bucket.load_balancer[0].arn}/*"
     ]
   }
 }
 
 # AWS S3 bucket to store RDS snapshots, used as data sources for Athena.
 resource "aws_s3_bucket" "athena_rds_snapshots" {
+  count         = var.indexer_enabled ? 1 : 0
   bucket        = "${local.account_id}-${var.environment}-${var.indexers[var.region].name}-athena-rds-snapshots"
   force_destroy = true
 
@@ -103,8 +110,8 @@ resource "aws_s3_bucket" "athena_rds_snapshots" {
 }
 
 resource "aws_s3_bucket_lifecycle_configuration" "athena_rds_snapshots" {
-  count  = var.enable_s3_rds_snapshot_lifecycle ? 1 : 0
-  bucket = aws_s3_bucket.athena_rds_snapshots.id
+  count  = var.indexer_enabled && var.enable_s3_rds_snapshot_lifecycle ? 1 : 0
+  bucket = aws_s3_bucket.athena_rds_snapshots[0].id
 
   rule {
     id     = "expire-old-snapshots"

--- a/indexer/s3_bucket.tf
+++ b/indexer/s3_bucket.tf
@@ -1,6 +1,6 @@
 # AWS S3 bucket to store all load balancer logs
 resource "aws_s3_bucket" "load_balancer" {
-  count         = var.indexer_enabled ? 1 : 0
+  count         = local.indexer_enabled ? 1 : 0
   bucket        = "${local.account_id}-${var.environment}-${var.indexers[var.region].name}-lb-public-logs"
   force_destroy = true
 
@@ -11,7 +11,7 @@ resource "aws_s3_bucket" "load_balancer" {
 }
 
 resource "aws_s3_bucket_lifecycle_configuration" "load_balancer" {
-  count  = var.indexer_enabled && var.enable_s3_load_balancer_logs_lifecycle ? 1 : 0
+  count  = local.indexer_enabled && var.enable_s3_load_balancer_logs_lifecycle ? 1 : 0
   bucket = aws_s3_bucket.load_balancer[0].id
 
   rule {
@@ -31,11 +31,11 @@ resource "aws_s3_bucket_lifecycle_configuration" "load_balancer" {
 # TODO: refactor snapshotting full node into a separate module
 # AWS S3 bucket to store all Indexer full node snapshots
 resource "aws_s3_bucket" "indexer_full_node_snapshots" {
-  count = var.indexer_enabled ? 1 : 0
+  count = local.indexer_enabled ? 1 : 0
   # Use account id for mainnet to avoid name collisions
   # TODO(IND-457): Migrate files in other envs and update bucket name
   bucket        = var.environment == "mainnet" ? "${local.account_id}-${var.s3_snapshot_bucket}" : var.s3_snapshot_bucket
-  force_destroy = var.indexer_teardown_disarm
+  force_destroy = local.indexer_teardown_disarm
 
   tags = {
     Name        = "${local.account_id}-${var.environment}-full-node-snapshots"
@@ -44,7 +44,7 @@ resource "aws_s3_bucket" "indexer_full_node_snapshots" {
 }
 
 resource "aws_s3_bucket_lifecycle_configuration" "indexer_full_node_snapshots" {
-  count  = var.indexer_enabled && var.enable_s3_snapshot_lifecycle ? 1 : 0
+  count  = local.indexer_enabled && var.enable_s3_snapshot_lifecycle ? 1 : 0
   bucket = aws_s3_bucket.indexer_full_node_snapshots[0].id
 
   rule {
@@ -64,7 +64,7 @@ resource "aws_s3_bucket_lifecycle_configuration" "indexer_full_node_snapshots" {
 
 # Enable S3 bucket metrics to be sent to Datadog for monitoring
 resource "aws_s3_bucket_metric" "indexer_full_node_snapshots" {
-  count  = var.indexer_enabled ? 1 : 0
+  count  = local.indexer_enabled ? 1 : 0
   bucket = aws_s3_bucket.indexer_full_node_snapshots[0].id
   name   = "EntireBucket"
 }
@@ -72,14 +72,14 @@ resource "aws_s3_bucket_metric" "indexer_full_node_snapshots" {
 # Attach policy to s3 bucket to allow load balancer to write logs to the S3 bucket
 # NOTE: This resource cannot be tagged.
 resource "aws_s3_bucket_policy" "lb_s3_bucket_policy" {
-  count  = var.indexer_enabled ? 1 : 0
+  count  = local.indexer_enabled ? 1 : 0
   bucket = aws_s3_bucket.load_balancer[0].id
   policy = data.aws_iam_policy_document.lb_s3_bucket_policy[0].json
 }
 
 # Policy to allow load balancer to write logs into the s3 bucket
 data "aws_iam_policy_document" "lb_s3_bucket_policy" {
-  count = var.indexer_enabled ? 1 : 0
+  count = local.indexer_enabled ? 1 : 0
   statement {
     principals {
       type        = "AWS"
@@ -99,7 +99,7 @@ data "aws_iam_policy_document" "lb_s3_bucket_policy" {
 
 # AWS S3 bucket to store RDS snapshots, used as data sources for Athena.
 resource "aws_s3_bucket" "athena_rds_snapshots" {
-  count         = var.indexer_enabled ? 1 : 0
+  count         = local.indexer_enabled ? 1 : 0
   bucket        = "${local.account_id}-${var.environment}-${var.indexers[var.region].name}-athena-rds-snapshots"
   force_destroy = true
 
@@ -110,7 +110,7 @@ resource "aws_s3_bucket" "athena_rds_snapshots" {
 }
 
 resource "aws_s3_bucket_lifecycle_configuration" "athena_rds_snapshots" {
-  count  = var.indexer_enabled && var.enable_s3_rds_snapshot_lifecycle ? 1 : 0
+  count  = local.indexer_enabled && var.enable_s3_rds_snapshot_lifecycle ? 1 : 0
   bucket = aws_s3_bucket.athena_rds_snapshots[0].id
 
   rule {

--- a/indexer/security_group.tf
+++ b/indexer/security_group.tf
@@ -2,7 +2,7 @@
 # RDS Security Group and Rules
 # ----------------------------------------------------------
 resource "aws_security_group" "rds" {
-  count  = var.indexer_enabled ? 1 : 0
+  count  = local.indexer_enabled ? 1 : 0
   name   = "${var.environment}-${var.indexers[var.region].name}-rds-sg"
   vpc_id = aws_vpc.main[0].id
 
@@ -50,7 +50,7 @@ resource "aws_security_group" "rds" {
 # MSK Security Group and Rules
 # ----------------------------------------------------------
 resource "aws_security_group" "msk" {
-  count  = var.indexer_enabled ? 1 : 0
+  count  = local.indexer_enabled ? 1 : 0
   name   = "${var.environment}-${var.indexers[var.region].name}-msk-sg"
   vpc_id = aws_vpc.main[0].id
 
@@ -100,7 +100,7 @@ resource "aws_security_group" "msk" {
 # Redis Security Group and Rules
 # ----------------------------------------------------------
 resource "aws_security_group" "redis" {
-  count  = var.indexer_enabled ? 1 : 0
+  count  = local.indexer_enabled ? 1 : 0
   name   = "${var.environment}-${var.indexers[var.region].name}-redis-sg"
   vpc_id = aws_vpc.main[0].id
 
@@ -168,7 +168,7 @@ resource "aws_security_group" "redis" {
 # Devbox security group will be used for EC2 instances that can be ssh'd into and can connect with
 # all the other indexer components that are kept in the private subnets, similar to v3 devboxes.
 resource "aws_security_group" "devbox" {
-  count  = var.indexer_enabled ? 1 : 0
+  count  = local.indexer_enabled ? 1 : 0
   name   = "${var.environment}-${var.indexers[var.region].name}-devbox-sg"
   vpc_id = aws_vpc.main[0].id
 
@@ -266,7 +266,7 @@ resource "aws_security_group_rule" "lb_public_to_services" {
 # Load balancer
 # ----------------------------------------------------------
 resource "aws_security_group" "load_balancer_public" {
-  count  = var.indexer_enabled ? 1 : 0
+  count  = local.indexer_enabled ? 1 : 0
   name   = "${var.environment}-${var.indexers[var.region].name}-lb-public-sg"
   vpc_id = aws_vpc.main[0].id
 
@@ -277,7 +277,7 @@ resource "aws_security_group" "load_balancer_public" {
 }
 
 resource "aws_security_group_rule" "outbound_traffic_from_load_balancer" {
-  count             = var.indexer_enabled && var.public_access ? 1 : 0
+  count             = local.indexer_enabled && var.public_access ? 1 : 0
   security_group_id = aws_security_group.load_balancer_public[0].id
   type              = "egress"
   from_port         = 0
@@ -289,7 +289,7 @@ resource "aws_security_group_rule" "outbound_traffic_from_load_balancer" {
 
 # Ingress rule for HTTP traffic for the load balancer
 resource "aws_security_group_rule" "inbound_http_to_load_balancer" {
-  count             = var.indexer_enabled && var.public_access ? 1 : 0
+  count             = local.indexer_enabled && var.public_access ? 1 : 0
   security_group_id = aws_security_group.load_balancer_public[0].id
   type              = "ingress"
   from_port         = 80
@@ -301,7 +301,7 @@ resource "aws_security_group_rule" "inbound_http_to_load_balancer" {
 
 # Ingress rule for HTTP traffic for the load balancer
 resource "aws_security_group_rule" "inbound_https_to_load_balancer" {
-  count             = var.indexer_enabled && var.public_access ? 1 : 0
+  count             = local.indexer_enabled && var.public_access ? 1 : 0
   security_group_id = aws_security_group.load_balancer_public[0].id
   type              = "ingress"
   from_port         = 443

--- a/indexer/security_group.tf
+++ b/indexer/security_group.tf
@@ -2,8 +2,9 @@
 # RDS Security Group and Rules
 # ----------------------------------------------------------
 resource "aws_security_group" "rds" {
+  count  = var.indexer_enabled ? 1 : 0
   name   = "${var.environment}-${var.indexers[var.region].name}-rds-sg"
-  vpc_id = aws_vpc.main.id
+  vpc_id = aws_vpc.main[0].id
 
   # Allow all traffic from the indexer's VPC cidr block, devboxes, lambdas services and ECS
   # services that require RDS for default postgres port.
@@ -13,7 +14,7 @@ resource "aws_security_group" "rds" {
     protocol    = "tcp"
     cidr_blocks = ["${var.indexers[var.region].vpc_cidr_block}"]
     security_groups = flatten([
-      aws_security_group.devbox.id,
+      aws_security_group.devbox[0].id,
       # Lambda Services
       [
         for service in keys(local.lambda_services) :
@@ -49,8 +50,9 @@ resource "aws_security_group" "rds" {
 # MSK Security Group and Rules
 # ----------------------------------------------------------
 resource "aws_security_group" "msk" {
+  count  = var.indexer_enabled ? 1 : 0
   name   = "${var.environment}-${var.indexers[var.region].name}-msk-sg"
-  vpc_id = aws_vpc.main.id
+  vpc_id = aws_vpc.main[0].id
 
   # Allow all traffic from the indexer's VPC cidr block, devboxes, lambda services, the V4 full
   # node and ECS services that require MSK for port 9092 (default kafka port)
@@ -60,8 +62,8 @@ resource "aws_security_group" "msk" {
     protocol    = "tcp"
     cidr_blocks = ["${var.indexers[var.region].vpc_cidr_block}"]
     security_groups = flatten([
-      aws_security_group.devbox.id,
-      module.full_node_ap_northeast_1.aws_security_group_id,
+      aws_security_group.devbox[0].id,
+      module.full_node_ap_northeast_1[0].aws_security_group_id,
       var.create_backup_full_node ? [module.backup_full_node_ap_northeast_1[0].aws_security_group_id] : [],
       # Lambda Services
       [
@@ -98,8 +100,9 @@ resource "aws_security_group" "msk" {
 # Redis Security Group and Rules
 # ----------------------------------------------------------
 resource "aws_security_group" "redis" {
+  count  = var.indexer_enabled ? 1 : 0
   name   = "${var.environment}-${var.indexers[var.region].name}-redis-sg"
-  vpc_id = aws_vpc.main.id
+  vpc_id = aws_vpc.main[0].id
 
   # Allow all traffic from devboxes, lambda services and ECS services that require redis
   # for port 6379 (default redis port)
@@ -109,7 +112,7 @@ resource "aws_security_group" "redis" {
     protocol    = "tcp"
     cidr_blocks = ["${var.indexers[var.region].vpc_cidr_block}"]
     security_groups = flatten([
-      aws_security_group.devbox.id,
+      aws_security_group.devbox[0].id,
       # Lambda Services
       [
         for service in keys(local.lambda_services) :
@@ -165,8 +168,9 @@ resource "aws_security_group" "redis" {
 # Devbox security group will be used for EC2 instances that can be ssh'd into and can connect with
 # all the other indexer components that are kept in the private subnets, similar to v3 devboxes.
 resource "aws_security_group" "devbox" {
+  count  = var.indexer_enabled ? 1 : 0
   name   = "${var.environment}-${var.indexers[var.region].name}-devbox-sg"
-  vpc_id = aws_vpc.main.id
+  vpc_id = aws_vpc.main[0].id
 
   # Allow ssh in from everywhere.
   ingress {
@@ -197,7 +201,7 @@ resource "aws_security_group" "services" {
   for_each = local.services
 
   name   = "${var.environment}-${var.indexers[var.region].name}-${each.key}-sg"
-  vpc_id = aws_vpc.main.id
+  vpc_id = aws_vpc.main[0].id
 
   # Allow all outbound traffic.
   # TODO(DEC-900): Investigate restricting security group permissions
@@ -232,8 +236,8 @@ resource "aws_security_group_rule" "devbox_to_services" {
   from_port                = each.value.port
   to_port                  = each.value.port
   protocol                 = "tcp"
-  source_security_group_id = aws_security_group.devbox.id
-  description              = aws_security_group.devbox.name
+  source_security_group_id = aws_security_group.devbox[0].id
+  description              = aws_security_group.devbox[0].name
 }
 
 # AWS security group rule to allow the loadbalance to access ports for all public facing services
@@ -254,16 +258,17 @@ resource "aws_security_group_rule" "lb_public_to_services" {
   from_port                = each.value.port
   to_port                  = each.value.port
   protocol                 = "tcp"
-  source_security_group_id = aws_security_group.load_balancer_public.id
-  description              = aws_security_group.load_balancer_public.name
+  source_security_group_id = aws_security_group.load_balancer_public[0].id
+  description              = aws_security_group.load_balancer_public[0].name
 }
 
 # ----------------------------------------------------------
 # Load balancer
 # ----------------------------------------------------------
 resource "aws_security_group" "load_balancer_public" {
+  count  = var.indexer_enabled ? 1 : 0
   name   = "${var.environment}-${var.indexers[var.region].name}-lb-public-sg"
-  vpc_id = aws_vpc.main.id
+  vpc_id = aws_vpc.main[0].id
 
   tags = {
     Name        = "${var.environment}-${var.indexers[var.region].name}-lb-public-sg"
@@ -272,8 +277,8 @@ resource "aws_security_group" "load_balancer_public" {
 }
 
 resource "aws_security_group_rule" "outbound_traffic_from_load_balancer" {
-  count             = var.public_access ? 1 : 0
-  security_group_id = aws_security_group.load_balancer_public.id
+  count             = var.indexer_enabled && var.public_access ? 1 : 0
+  security_group_id = aws_security_group.load_balancer_public[0].id
   type              = "egress"
   from_port         = 0
   to_port           = 0
@@ -284,8 +289,8 @@ resource "aws_security_group_rule" "outbound_traffic_from_load_balancer" {
 
 # Ingress rule for HTTP traffic for the load balancer
 resource "aws_security_group_rule" "inbound_http_to_load_balancer" {
-  count             = var.public_access ? 1 : 0
-  security_group_id = aws_security_group.load_balancer_public.id
+  count             = var.indexer_enabled && var.public_access ? 1 : 0
+  security_group_id = aws_security_group.load_balancer_public[0].id
   type              = "ingress"
   from_port         = 80
   to_port           = 80
@@ -296,8 +301,8 @@ resource "aws_security_group_rule" "inbound_http_to_load_balancer" {
 
 # Ingress rule for HTTP traffic for the load balancer
 resource "aws_security_group_rule" "inbound_https_to_load_balancer" {
-  count             = var.public_access ? 1 : 0
-  security_group_id = aws_security_group.load_balancer_public.id
+  count             = var.indexer_enabled && var.public_access ? 1 : 0
+  security_group_id = aws_security_group.load_balancer_public[0].id
   type              = "ingress"
   from_port         = 443
   to_port           = 443
@@ -313,7 +318,7 @@ resource "aws_security_group" "lambda_services" {
   for_each = local.lambda_services
 
   name   = "${var.environment}-${var.indexers[var.region].name}-${each.key}-sg"
-  vpc_id = aws_vpc.main.id
+  vpc_id = aws_vpc.main[0].id
 
   # Allow ssh in from everywhere.
   ingress {

--- a/indexer/snapshot_full_node_ap_northeast_1.tf
+++ b/indexer/snapshot_full_node_ap_northeast_1.tf
@@ -1,4 +1,5 @@
 module "full_node_snapshot_ap_northeast_1" {
+  count  = var.indexer_enabled ? 1 : 0
   source = "../modules/validator"
 
   environment = var.environment
@@ -73,7 +74,7 @@ module "full_node_snapshot_ap_northeast_1" {
   additional_task_role_policies = [
     {
       name  = "S3 snapshot bucket access",
-      value = aws_iam_policy.ecs_task_s3_policy.arn,
+      value = aws_iam_policy.ecs_task_s3_policy[0].arn,
     },
   ]
 

--- a/indexer/snapshot_full_node_ap_northeast_1.tf
+++ b/indexer/snapshot_full_node_ap_northeast_1.tf
@@ -1,5 +1,5 @@
 module "full_node_snapshot_ap_northeast_1" {
-  count  = var.indexer_enabled ? 1 : 0
+  count  = local.indexer_enabled ? 1 : 0
   source = "../modules/validator"
 
   environment = var.environment

--- a/indexer/snapshot_iam.tf
+++ b/indexer/snapshot_iam.tf
@@ -11,6 +11,7 @@ data "aws_iam_policy_document" "ecs_task_s3_policy" {
 }
 
 resource "aws_iam_policy" "ecs_task_s3_policy" {
+  count       = var.indexer_enabled ? 1 : 0
   name        = "${var.environment}-${var.indexers[var.region].name}-ecs_task_s3_policy"
   description = "Allows ECS tasks to access S3"
 

--- a/indexer/snapshot_iam.tf
+++ b/indexer/snapshot_iam.tf
@@ -11,7 +11,7 @@ data "aws_iam_policy_document" "ecs_task_s3_policy" {
 }
 
 resource "aws_iam_policy" "ecs_task_s3_policy" {
-  count       = var.indexer_enabled ? 1 : 0
+  count       = local.indexer_enabled ? 1 : 0
   name        = "${var.environment}-${var.indexers[var.region].name}-ecs_task_s3_policy"
   description = "Allows ECS tasks to access S3"
 

--- a/indexer/teardown.tf
+++ b/indexer/teardown.tf
@@ -1,0 +1,27 @@
+# -----------------------------------------------------------------------------
+# Internal-mainnet teardown gate
+# -----------------------------------------------------------------------------
+# These two workspace-scoped switches drive the wind-down of the internal-mainnet
+# indexer while keeping Terraform state + config intact for an emergency rebuild.
+# Both default to today's behavior, so dev / staging / testnet (which share this
+# root module in separate workspaces) are unaffected. Only the internal-mainnet
+# `indexers` workspace ever sets them. See teardown_moved.tf for the address
+# migrations that make the default (enabled) path a no-op for existing state.
+
+# Master existence switch for every resource + module in this workspace. When
+# false, every gated resource/module drops to count 0 (and the service/az source
+# locals empty out, collapsing every for_each), destroying the full stack.
+variable "indexer_enabled" {
+  type    = bool
+  default = true
+}
+
+# Disarms delete guards so the teardown destroy can proceed. Set to true one apply
+# BEFORE indexer_enabled is flipped to false: drops RDS deletion_protection and
+# enables force_destroy on the full-node snapshot S3 bucket. (The prevent_destroy
+# lifecycle guards on the main ElastiCache group and ACM cert are literals and are
+# dropped in code, not via this flag.)
+variable "indexer_teardown_disarm" {
+  type    = bool
+  default = false
+}

--- a/indexer/teardown.tf
+++ b/indexer/teardown.tf
@@ -1,27 +1,40 @@
 # -----------------------------------------------------------------------------
 # Internal-mainnet teardown gate
 # -----------------------------------------------------------------------------
-# These two workspace-scoped switches drive the wind-down of the internal-mainnet
-# indexer while keeping Terraform state + config intact for an emergency rebuild.
-# Both default to today's behavior, so dev / staging / testnet (which share this
-# root module in separate workspaces) are unaffected. Only the internal-mainnet
-# `indexers` workspace ever sets them. See teardown_moved.tf for the address
-# migrations that make the default (enabled) path a no-op for existing state.
+# The internal-mainnet indexer is wound down to remove its AWS cost while keeping
+# Terraform state + config intact for an emergency rebuild. Internal mainnet is the
+# ONLY workspace with environment = "mainnet", so the teardown is derived from the
+# environment rather than a workspace variable: it is intrinsic to the mainnet
+# workspace and cannot be undone by an errant apply or a forgotten/unset variable.
+# dev / staging / testnet (which share this root module in separate workspaces) are
+# unaffected — the derived values are identical to the historical behavior there.
 
-# Master existence switch for every resource + module in this workspace. When
-# false, every gated resource/module drops to count 0 (and the service/az source
-# locals empty out, collapsing every for_each), destroying the full stack.
+# Optional override for the master existence gate. Leave null (default) to derive
+# from the environment: mainnet => disabled (full teardown), everything else =>
+# enabled. Set to true on the mainnet workspace to rebuild for an emergency restore.
 variable "indexer_enabled" {
   type    = bool
-  default = true
+  default = null
 }
 
-# Disarms delete guards so the teardown destroy can proceed. Set to true one apply
-# BEFORE indexer_enabled is flipped to false: drops RDS deletion_protection and
-# enables force_destroy on the full-node snapshot S3 bucket. (The prevent_destroy
-# lifecycle guards on the main ElastiCache group and ACM cert are literals and are
-# dropped in code, not via this flag.)
+# Optional override for the delete-guard disarm switch. Leave null (default) to
+# derive from the environment: mainnet => disarmed (drops RDS deletion_protection
+# and enables force_destroy on the full-node snapshot S3 bucket so the destroy can
+# complete), everything else => armed. On restore, set both overrides explicitly
+# (indexer_enabled = true, indexer_teardown_disarm = false).
 variable "indexer_teardown_disarm" {
   type    = bool
-  default = false
+  default = null
+}
+
+locals {
+  # Master existence gate for every resource + module in this workspace. When
+  # false, every gated resource/module drops to count 0 and the service/az source
+  # locals empty out (collapsing every for_each), tearing down the full stack.
+  indexer_enabled = var.indexer_enabled != null ? var.indexer_enabled : var.environment != "mainnet"
+
+  # Disarms delete guards so the teardown destroy can proceed. (The prevent_destroy
+  # lifecycle guards on the main ElastiCache group and ACM cert are literals and are
+  # dropped in code, not via this switch.)
+  indexer_teardown_disarm = var.indexer_teardown_disarm != null ? var.indexer_teardown_disarm : var.environment == "mainnet"
 }

--- a/indexer/teardown_moved.tf
+++ b/indexer/teardown_moved.tf
@@ -1,0 +1,274 @@
+# Address migrations for the indexer_enabled teardown gate.
+# Adding `count` to a previously count-less resource changes its address
+# (foo.bar -> foo.bar[0]); these moved blocks keep existing state (all
+# environments default indexer_enabled=true) from proposing destroy+recreate.
+
+moved {
+  from = aws_glue_catalog_database.rds_snapshots
+  to   = aws_glue_catalog_database.rds_snapshots[0]
+}
+
+moved {
+  from = aws_cloudformation_stack.datadog_forwarder
+  to   = aws_cloudformation_stack.datadog_forwarder[0]
+}
+
+moved {
+  from = aws_ecs_cluster.main
+  to   = aws_ecs_cluster.main[0]
+}
+
+moved {
+  from = aws_iam_policy.kms_policy
+  to   = aws_iam_policy.kms_policy[0]
+}
+
+moved {
+  from = aws_kms_key.rds_export
+  to   = aws_kms_key.rds_export[0]
+}
+
+moved {
+  from = aws_iam_policy.lambda_upgrade_indexer_policy
+  to   = aws_iam_policy.lambda_upgrade_indexer_policy[0]
+}
+
+moved {
+  from = aws_iam_policy.ecs_task_s3_policy
+  to   = aws_iam_policy.ecs_task_s3_policy[0]
+}
+
+moved {
+  from = aws_lb.public
+  to   = aws_lb.public[0]
+}
+
+moved {
+  from = aws_lb_listener.public_http
+  to   = aws_lb_listener.public_http[0]
+}
+
+moved {
+  from = aws_lb_listener_rule.public_http_socks
+  to   = aws_lb_listener_rule.public_http_socks[0]
+}
+
+moved {
+  from = aws_lb_listener_rule.public_http_comlink
+  to   = aws_lb_listener_rule.public_http_comlink[0]
+}
+
+moved {
+  from = aws_msk_configuration.main
+  to   = aws_msk_configuration.main[0]
+}
+
+moved {
+  from = aws_msk_cluster.main
+  to   = aws_msk_cluster.main[0]
+}
+
+moved {
+  from = aws_network_acl.public
+  to   = aws_network_acl.public[0]
+}
+
+moved {
+  from = aws_network_acl_rule.public_egress_allow_all
+  to   = aws_network_acl_rule.public_egress_allow_all[0]
+}
+
+moved {
+  from = aws_network_acl_rule.public_ingress_allow_all_from_vpc
+  to   = aws_network_acl_rule.public_ingress_allow_all_from_vpc[0]
+}
+
+moved {
+  from = aws_network_acl_rule.public_ingress_allow_all_tcp
+  to   = aws_network_acl_rule.public_ingress_allow_all_tcp[0]
+}
+
+moved {
+  from = aws_network_acl_rule.public_ingress_allow_all_udp
+  to   = aws_network_acl_rule.public_ingress_allow_all_udp[0]
+}
+
+moved {
+  from = aws_network_acl_rule.public_ingress_allow_ssh
+  to   = aws_network_acl_rule.public_ingress_allow_ssh[0]
+}
+
+moved {
+  from = aws_network_acl.private
+  to   = aws_network_acl.private[0]
+}
+
+moved {
+  from = aws_network_acl_rule.private_egress_allow_all
+  to   = aws_network_acl_rule.private_egress_allow_all[0]
+}
+
+moved {
+  from = aws_network_acl_rule.private_ingress_allow_all_from_vpc
+  to   = aws_network_acl_rule.private_ingress_allow_all_from_vpc[0]
+}
+
+moved {
+  from = aws_network_acl_rule.private_ingress_allow_all_tcp
+  to   = aws_network_acl_rule.private_ingress_allow_all_tcp[0]
+}
+
+moved {
+  from = aws_network_acl_rule.private_ingress_allow_all_udp
+  to   = aws_network_acl_rule.private_ingress_allow_all_udp[0]
+}
+
+moved {
+  from = aws_network_acl_rule.private_ingress_allow_ssh
+  to   = aws_network_acl_rule.private_ingress_allow_ssh[0]
+}
+
+moved {
+  from = aws_route53_zone.main
+  to   = aws_route53_zone.main[0]
+}
+
+moved {
+  from = aws_db_subnet_group.main
+  to   = aws_db_subnet_group.main[0]
+}
+
+moved {
+  from = aws_db_parameter_group.main
+  to   = aws_db_parameter_group.main[0]
+}
+
+moved {
+  from = aws_db_instance.main
+  to   = aws_db_instance.main[0]
+}
+
+moved {
+  from = aws_route_table.public
+  to   = aws_route_table.public[0]
+}
+
+moved {
+  from = aws_route.public
+  to   = aws_route.public[0]
+}
+
+moved {
+  from = aws_route.full_node_route_to_indexer
+  to   = aws_route.full_node_route_to_indexer[0]
+}
+
+moved {
+  from = aws_security_group.rds
+  to   = aws_security_group.rds[0]
+}
+
+moved {
+  from = aws_security_group.msk
+  to   = aws_security_group.msk[0]
+}
+
+moved {
+  from = aws_security_group.redis
+  to   = aws_security_group.redis[0]
+}
+
+moved {
+  from = aws_security_group.devbox
+  to   = aws_security_group.devbox[0]
+}
+
+moved {
+  from = aws_security_group.load_balancer_public
+  to   = aws_security_group.load_balancer_public[0]
+}
+
+moved {
+  from = aws_s3_bucket.load_balancer
+  to   = aws_s3_bucket.load_balancer[0]
+}
+
+moved {
+  from = aws_s3_bucket_metric.indexer_full_node_snapshots
+  to   = aws_s3_bucket_metric.indexer_full_node_snapshots[0]
+}
+
+moved {
+  from = aws_s3_bucket_policy.lb_s3_bucket_policy
+  to   = aws_s3_bucket_policy.lb_s3_bucket_policy[0]
+}
+
+moved {
+  from = aws_s3_bucket.indexer_full_node_snapshots
+  to   = aws_s3_bucket.indexer_full_node_snapshots[0]
+}
+
+moved {
+  from = aws_s3_bucket.athena_rds_snapshots
+  to   = aws_s3_bucket.athena_rds_snapshots[0]
+}
+
+moved {
+  from = aws_vpc.main
+  to   = aws_vpc.main[0]
+}
+
+moved {
+  from = aws_internet_gateway.main
+  to   = aws_internet_gateway.main[0]
+}
+
+moved {
+  from = aws_vpc_peering_connection.full_node_peer
+  to   = aws_vpc_peering_connection.full_node_peer[0]
+}
+
+moved {
+  from = aws_elasticache_subnet_group.main
+  to   = aws_elasticache_subnet_group.main[0]
+}
+
+moved {
+  from = aws_elasticache_replication_group.main
+  to   = aws_elasticache_replication_group.main[0]
+}
+
+moved {
+  from = aws_elasticache_subnet_group.rate_limit
+  to   = aws_elasticache_subnet_group.rate_limit[0]
+}
+
+moved {
+  from = aws_elasticache_replication_group.rate_limit
+  to   = aws_elasticache_replication_group.rate_limit[0]
+}
+
+moved {
+  from = module.datadog_agent
+  to   = module.datadog_agent[0]
+}
+
+moved {
+  from = module.iam_ecs_task_roles
+  to   = module.iam_ecs_task_roles[0]
+}
+
+moved {
+  from = module.iam_github_actions
+  to   = module.iam_github_actions[0]
+}
+
+moved {
+  from = module.full_node_ap_northeast_1
+  to   = module.full_node_ap_northeast_1[0]
+}
+
+moved {
+  from = module.full_node_snapshot_ap_northeast_1
+  to   = module.full_node_snapshot_ap_northeast_1[0]
+}

--- a/indexer/vpc.tf
+++ b/indexer/vpc.tf
@@ -1,6 +1,6 @@
 # Main VPC for the indexer components in the region
 resource "aws_vpc" "main" {
-  count                = var.indexer_enabled ? 1 : 0
+  count                = local.indexer_enabled ? 1 : 0
   cidr_block           = var.indexers[var.region].vpc_cidr_block
   enable_dns_hostnames = true
   tags = {
@@ -37,7 +37,7 @@ resource "aws_subnet" "public_subnets" {
 
 # Internet Gateway to connect VPC to the internet.
 resource "aws_internet_gateway" "main" {
-  count  = var.indexer_enabled ? 1 : 0
+  count  = local.indexer_enabled ? 1 : 0
   vpc_id = aws_vpc.main[0].id
 
   tags = {
@@ -71,7 +71,7 @@ resource "aws_eip" "main" {
 
 # VPC Peer resource between the Indexer and a full node's VPC
 resource "aws_vpc_peering_connection" "full_node_peer" {
-  count       = var.indexer_enabled ? 1 : 0
+  count       = local.indexer_enabled ? 1 : 0
   peer_vpc_id = aws_vpc.main[0].id
   vpc_id      = module.full_node_ap_northeast_1[0].aws_vpc_id
   # Auto-accept allows the VPC peering connection to be made programmatically with no manual steps
@@ -86,7 +86,7 @@ resource "aws_vpc_peering_connection" "full_node_peer" {
 }
 
 resource "aws_vpc_peering_connection" "backup_full_node_peer" {
-  count       = var.indexer_enabled && var.create_backup_full_node ? 1 : 0
+  count       = local.indexer_enabled && var.create_backup_full_node ? 1 : 0
   peer_vpc_id = aws_vpc.main[0].id
   vpc_id      = module.backup_full_node_ap_northeast_1[0].aws_vpc_id
   # Auto-accept allows the VPC peering connection to be made programmatically with no manual steps

--- a/indexer/vpc.tf
+++ b/indexer/vpc.tf
@@ -1,5 +1,6 @@
 # Main VPC for the indexer components in the region
 resource "aws_vpc" "main" {
+  count                = var.indexer_enabled ? 1 : 0
   cidr_block           = var.indexers[var.region].vpc_cidr_block
   enable_dns_hostnames = true
   tags = {
@@ -10,9 +11,9 @@ resource "aws_vpc" "main" {
 
 # Public facing subnet.
 resource "aws_subnet" "private_subnets" {
-  for_each = toset(var.indexers[var.region].availability_zones)
+  for_each = local.azs
 
-  vpc_id            = aws_vpc.main.id
+  vpc_id            = aws_vpc.main[0].id
   cidr_block        = var.indexers[var.region].private_subnets_availability_zone_to_cidr_block[each.key]
   availability_zone = each.key
   tags = {
@@ -23,9 +24,9 @@ resource "aws_subnet" "private_subnets" {
 
 # Private facing subnet.
 resource "aws_subnet" "public_subnets" {
-  for_each = toset(var.indexers[var.region].availability_zones)
+  for_each = local.azs
 
-  vpc_id            = aws_vpc.main.id
+  vpc_id            = aws_vpc.main[0].id
   cidr_block        = var.indexers[var.region].public_subnets_availability_zone_to_cidr_block[each.key]
   availability_zone = each.key
   tags = {
@@ -36,7 +37,8 @@ resource "aws_subnet" "public_subnets" {
 
 # Internet Gateway to connect VPC to the internet.
 resource "aws_internet_gateway" "main" {
-  vpc_id = aws_vpc.main.id
+  count  = var.indexer_enabled ? 1 : 0
+  vpc_id = aws_vpc.main[0].id
 
   tags = {
     Name        = "${var.environment}-${var.indexers[var.region].name}-igw"
@@ -59,7 +61,7 @@ resource "aws_nat_gateway" "main" {
 
 # Elastic IP Addresses for the NAT Gateway
 resource "aws_eip" "main" {
-  for_each = toset(var.indexers[var.region].availability_zones)
+  for_each = local.azs
 
   tags = {
     Name        = "${var.environment}-${var.indexers[var.region].name}-${each.key}-nat-gateway-eip"
@@ -69,8 +71,9 @@ resource "aws_eip" "main" {
 
 # VPC Peer resource between the Indexer and a full node's VPC
 resource "aws_vpc_peering_connection" "full_node_peer" {
-  peer_vpc_id = aws_vpc.main.id
-  vpc_id      = module.full_node_ap_northeast_1.aws_vpc_id
+  count       = var.indexer_enabled ? 1 : 0
+  peer_vpc_id = aws_vpc.main[0].id
+  vpc_id      = module.full_node_ap_northeast_1[0].aws_vpc_id
   # Auto-accept allows the VPC peering connection to be made programmatically with no manual steps
   # to accept the VPC peering connection in the console
   # This can only be done if both VPCs are in the same region and AWS account (which they are)
@@ -83,8 +86,8 @@ resource "aws_vpc_peering_connection" "full_node_peer" {
 }
 
 resource "aws_vpc_peering_connection" "backup_full_node_peer" {
-  count       = var.create_backup_full_node ? 1 : 0
-  peer_vpc_id = aws_vpc.main.id
+  count       = var.indexer_enabled && var.create_backup_full_node ? 1 : 0
+  peer_vpc_id = aws_vpc.main[0].id
   vpc_id      = module.backup_full_node_ap_northeast_1[0].aws_vpc_id
   # Auto-accept allows the VPC peering connection to be made programmatically with no manual steps
   # to accept the VPC peering connection in the console


### PR DESCRIPTION
Winds down the internal-mainnet indexer to zero cost while keeping its Terraform state and config intact for a one-switch rebuild. The gate is derived from `environment` — mainnet is torn down by default and no errant apply can re-provision it — so every other workspace is untouched.

## What it is

A teardown gate on the shared `indexer/` root. Internal mainnet is the only `environment = "mainnet"` workspace, so the behavior is derived, not variable-driven:

| Workspace | Result |
|---|---|
| internal mainnet | full teardown, effective on merge |
| dev / staging / testnet | unchanged (no-op) |
| mainnet + `indexer_enabled = true` | rebuild (restore) |

## Capabilities

| Property | Delivered |
|---|---|
| Isolation | Non-mainnet workspaces see zero resource changes. |
| Teardown durability | The torn-down state is intrinsic to the workspace; an apply can only re-confirm it, never re-provision. |
| State preservation | Existing state migrates in place — no destroy+recreate — and config is retained. |
| Restore | A single override switch plus a production DB snapshot rebuilds the topology. |
| Dependency safety | External node images and service secrets are read-only and never destroyed. |

## Testing

- `terraform validate` (tf 1.3.2) and `fmt` pass; validate exercises the non-mainnet path and proves every gated reference resolves.
- `terraform console` confirms the derived values per environment — mainnet off, others on, override restores.
- Structural sweep: no resource or module is left ungated; delete guards are all switch-driven.
- **Merge gate:** speculative plans on dev / staging / testnet must each show 0 resource changes.

## Reviewer brief

- `teardown.tf` — the whole contract: two override variables and the environment-derived gate. Confirm it keys on `environment == "mainnet"`.
- `locals.tf` — the service/AZ source collections that empty out when disabled, collapsing every `for_each`.
- `teardown_moved.tf` — 54 state-address migrations; a missing one makes a workspace propose destroy+recreate (caught by the merge gate).

Everything else is the mechanical gating those three drive.

## Out of scope

- `metric_ingestor/` and `amplitude_api_gateway/` workspaces.
- External metadata and standalone full-node services (other accounts).
- Deleting the TF Cloud workspace, its variables, or state history — retained for restore.

## Test plan

- [x] `terraform validate` + `fmt` (tf 1.3.2)
- [x] `terraform console` — derived values per environment
- [x] Structural sweep — 0 ungated resources/modules, guards switch-driven
- [ ] Speculative plan: dev / staging / testnet → 0 resource changes
- [ ] Mainnet plan → destroy-only, no creates/updates
