### PR TITLE
chore: decommission dev4 environment

### DIFF
--- a/indexer/variables.tf
+++ b/indexer/variables.tf
@@ -38,14 +38,14 @@ variable "indexers" {
 
 variable "environment" {
   type        = string
-  description = "Name of the environment {dev | dev2 | dev3 | dev4 | dev5 | staging | testnet | public-testnet | testnet1 | testnet2 | mainnet}."
+  description = "Name of the environment {dev | dev2 | dev3 | dev5 | staging | testnet | public-testnet | testnet1 | testnet2 | mainnet}."
 
   validation {
     condition = contains(
-      ["dev", "dev2", "dev3", "dev4", "dev5", "staging", "testnet", "public-testnet", "testnet1", "testnet2", "mainnet"],
+      ["dev", "dev2", "dev3", "dev5", "staging", "testnet", "public-testnet", "testnet1", "testnet2", "mainnet"],
       var.environment
     )
-    error_message = "Err: invalid environment. Must be one of {dev | dev2 | dev3 | dev4 | dev5 | staging | testnet | public-testnet | testnet1 | testnet2 | mainnet}."
+    error_message = "Err: invalid environment. Must be one of {dev | dev2 | dev3 | dev5 | staging | testnet | public-testnet | testnet1 | testnet2 | mainnet}."
   }
 }
 

--- a/metric_ingestor/variables.tf
+++ b/metric_ingestor/variables.tf
@@ -18,14 +18,14 @@ variable "datadog_site" {
 
 variable "environment" {
   type        = string
-  description = "Name of the environment {dev | dev2 | dev3 | dev4 | dev5 | staging | testnet | public-testnet | testnet1 | testnet2 | mainnet}."
+  description = "Name of the environment {dev | dev2 | dev3 | dev5 | staging | testnet | public-testnet | testnet1 | testnet2 | mainnet}."
 
   validation {
     condition = contains(
-      ["dev", "dev2", "dev3", "dev4", "dev5", "staging", "testnet", "public-testnet", "testnet1", "testnet2", "mainnet"],
+      ["dev", "dev2", "dev3", "dev5", "staging", "testnet", "public-testnet", "testnet1", "testnet2", "mainnet"],
       var.environment
     )
-    error_message = "Err: invalid environment. Must be one of {dev | dev2 | dev3 | dev4 | dev5 | staging | testnet | public-testnet | testnet1 | testnet2 | mainnet}."
+    error_message = "Err: invalid environment. Must be one of {dev | dev2 | dev3 | dev5 | staging | testnet | public-testnet | testnet1 | testnet2 | mainnet}."
   }
 }
 

--- a/modules/datadog_agent/log_forwarder/variables.tf
+++ b/modules/datadog_agent/log_forwarder/variables.tf
@@ -1,13 +1,13 @@
 variable "environment" {
   type        = string
-  description = "Name of the environment {dev | dev2 | dev3 | dev4 | dev5 | staging | testnet | public-testnet | testnet1 | testnet2 | mainnet}."
+  description = "Name of the environment {dev | dev2 | dev3 | dev5 | staging | testnet | public-testnet | testnet1 | testnet2 | mainnet}."
 
   validation {
     condition = contains(
-      ["dev", "dev2", "dev3", "dev4", "dev5", "staging", "testnet", "public-testnet", "testnet1", "testnet2", "mainnet"],
+      ["dev", "dev2", "dev3", "dev5", "staging", "testnet", "public-testnet", "testnet1", "testnet2", "mainnet"],
       var.environment
     )
-    error_message = "Err: invalid environment. Must be one of {dev | dev2 | dev3 | dev4 | dev5 | staging | testnet | public-testnet | testnet1 | testnet2 | mainnet}."
+    error_message = "Err: invalid environment. Must be one of {dev | dev2 | dev3 | dev5 | staging | testnet | public-testnet | testnet1 | testnet2 | mainnet}."
   }
 }
 

--- a/modules/datadog_agent/variables.tf
+++ b/modules/datadog_agent/variables.tf
@@ -1,6 +1,6 @@
 variable "env" {
   default     = "dev"
-  description = "dev/dev2/dev3/dev4/dev5/staging/testnet/public-testnet/testnet1/testnet2/mainnet"
+  description = "dev/dev2/dev3/dev5/staging/testnet/public-testnet/testnet1/testnet2/mainnet"
 }
 
 variable "name" {

--- a/modules/iam/ecs_task_roles/variables.tf
+++ b/modules/iam/ecs_task_roles/variables.tf
@@ -5,14 +5,14 @@ variable "name" {
 
 variable "environment" {
   type        = string
-  description = "Name of the environment {dev | dev2 | dev3 | dev4 | dev5 | staging | testnet | public-testnet | research | testnet1 | testnet2 | mainnet}."
+  description = "Name of the environment {dev | dev2 | dev3 | dev5 | staging | testnet | public-testnet | research | testnet1 | testnet2 | mainnet}."
 
   validation {
     condition = contains(
-      ["dev", "dev2", "dev3", "dev4", "dev5", "staging", "testnet", "public-testnet", "research", "testnet1", "testnet2", "mainnet"],
+      ["dev", "dev2", "dev3", "dev5", "staging", "testnet", "public-testnet", "research", "testnet1", "testnet2", "mainnet"],
       var.environment
     )
-    error_message = "Err: invalid environment. Must be one of {dev | dev2 | dev3 | dev4 | dev5 | staging | testnet | public-testnet | research | testnet1 | testnet2 | mainnet}."
+    error_message = "Err: invalid environment. Must be one of {dev | dev2 | dev3 | dev5 | staging | testnet | public-testnet | research | testnet1 | testnet2 | mainnet}."
   }
 }
 

--- a/modules/iam/github_actions_role/variables.tf
+++ b/modules/iam/github_actions_role/variables.tf
@@ -5,14 +5,14 @@ variable "name" {
 
 variable "environment" {
   type        = string
-  description = "Name of the environment {dev | dev2 | dev3 | dev4 | dev5 | staging | testnet | public-testnet | research | testnet1 | testnet2 | mainnet}."
+  description = "Name of the environment {dev | dev2 | dev3 | dev5 | staging | testnet | public-testnet | research | testnet1 | testnet2 | mainnet}."
 
   validation {
     condition = contains(
-      ["dev", "dev2", "dev3", "dev4", "dev5", "staging", "testnet", "public-testnet", "research", "testnet1", "testnet2", "mainnet"],
+      ["dev", "dev2", "dev3", "dev5", "staging", "testnet", "public-testnet", "research", "testnet1", "testnet2", "mainnet"],
       var.environment
     )
-    error_message = "Err: invalid environment. Must be one of {dev | dev2 | dev3 | dev4 | dev5 | staging | testnet | public-testnet | research | testnet1 | testnet2 | mainnet}."
+    error_message = "Err: invalid environment. Must be one of {dev | dev2 | dev3 | dev5 | staging | testnet | public-testnet | research | testnet1 | testnet2 | mainnet}."
   }
 }
 

--- a/modules/metric_ingestor/variables.tf
+++ b/modules/metric_ingestor/variables.tf
@@ -3,14 +3,14 @@
 # -----------------------------------------------------------------------------
 variable "environment" {
   type        = string
-  description = "Name of the environment {dev | dev2 | dev3 | dev4 | dev5 | staging | testnet | public-testnet | testnet1 | testnet2 | mainnet}."
+  description = "Name of the environment {dev | dev2 | dev3 | dev5 | staging | testnet | public-testnet | testnet1 | testnet2 | mainnet}."
 
   validation {
     condition = contains(
-      ["dev", "dev2", "dev3", "dev4", "dev5", "staging", "testnet", "public-testnet", "testnet1", "testnet2", "mainnet"],
+      ["dev", "dev2", "dev3", "dev5", "staging", "testnet", "public-testnet", "testnet1", "testnet2", "mainnet"],
       var.environment
     )
-    error_message = "Err: invalid environment. Must be one of {dev | dev2 | dev3 | dev4 | dev5 | staging | testnet | public-testnet | testnet1 | testnet2 | mainnet}."
+    error_message = "Err: invalid environment. Must be one of {dev | dev2 | dev3 | dev5 | staging | testnet | public-testnet | testnet1 | testnet2 | mainnet}."
   }
 }
 

--- a/modules/validator/variables.tf
+++ b/modules/validator/variables.tf
@@ -3,14 +3,14 @@
 # -----------------------------------------------------------------------------
 variable "environment" {
   type        = string
-  description = "Name of the environment {dev | dev2 | dev3 | dev4 | dev5 | staging | testnet | public-testnet | research | testnet1 | testnet2 | mainnet}."
+  description = "Name of the environment {dev | dev2 | dev3 | dev5 | staging | testnet | public-testnet | research | testnet1 | testnet2 | mainnet}."
 
   validation {
     condition = contains(
-      ["dev", "dev2", "dev3", "dev4", "dev5", "staging", "testnet", "public-testnet", "research", "testnet1", "testnet2", "mainnet"],
+      ["dev", "dev2", "dev3", "dev5", "staging", "testnet", "public-testnet", "research", "testnet1", "testnet2", "mainnet"],
       var.environment
     )
-    error_message = "Err: invalid environment. Must be one of {dev | dev2 | dev3 | dev4 | dev5 | staging | testnet | public-testnet | research | testnet1 | testnet2 | mainnet}."
+    error_message = "Err: invalid environment. Must be one of {dev | dev2 | dev3 | dev5 | staging | testnet | public-testnet | research | testnet1 | testnet2 | mainnet}."
   }
 }
 


### PR DESCRIPTION
## What it is

The AWS account behind the `dev4` environment (`525975847385`, `AWS_PROFILE=dydx-dev-4`) is being repurposed for security development. This PR removes `dev4` from the Terraform `environment` variable allowlists, descriptions, and error messages across the root modules and shared modules. Companion to the `v4-chain` CI cleanup (dydxprotocol/v4-chain#3373).

`dev4` is not a directory or `.tfvars` in this repo — it is an `environment` value set per-workspace in Terraform Cloud. Removing it from the `contains([...])` allowlist is a **no-op plan for every other workspace** (their `environment != dev4`), so this does not change dev/dev2/dev3/dev5/staging/testnet/mainnet.

## ⚠️ Merge ordering

Merge this **only after** the `dev4` Terraform Cloud workspaces have been destroyed and deleted. While a `dev4` workspace still exists, tightening the allowlist would make its next run fail validation. The live wind-down (queue destroy → confirm → delete workspace, plus orb-lambda validator/network teardown in `525975847385`) is done out-of-band.

## Capabilities table

| Property | Result |
|---|---|
| `dev4` accepted as an environment | Removed from allowlist, descriptions, and error messages |
| Other environments | Unchanged (allowlist entries preserved; `research`/`testnet1`/`testnet2` variants intact per-file) |
| Plan impact on live workspaces | None — no resource is gated on `environment == "dev4"` |
| Formatting | `terraform fmt -check -recursive` passes |

## Reviewer brief

Purely the `environment` variable definition in 8 files: `indexer/variables.tf`, `metric_ingestor/variables.tf`, `modules/metric_ingestor/variables.tf`, `modules/validator/variables.tf`, `modules/datadog_agent/variables.tf`, `modules/datadog_agent/log_forwarder/variables.tf`, `modules/iam/github_actions_role/variables.tf`, `modules/iam/ecs_task_roles/variables.tf`. Each drops the `dev4` token from the description string, the `contains()` list, and the error message (datadog_agent uses the slash-delimited single-line form).

## Out of scope
- Live Terraform Cloud workspace destroy + AWS teardown in `525975847385`.
- `v4-chain` CI/tooling cleanup (companion PR #3373).

## Test plan
- [x] No residual `dev4` references (`grep -rInE dev4`)
- [x] `terraform fmt -check -recursive` passes
- [ ] Merge gated on dev4 TFC workspaces destroyed + deleted